### PR TITLE
iCalイベントにカレンダー名を表示

### DIFF
--- a/components/calendar/EventCard.tsx
+++ b/components/calendar/EventCard.tsx
@@ -81,6 +81,31 @@ const DEFAULT_COLOR = "#6b7280";
 // ============================================================
 
 /**
+ * カレンダーソースアイコン（SVG）- iCal用
+ */
+function CalendarSourceIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			className={css({
+				width: "3.5",
+				height: "3.5",
+				flexShrink: 0,
+			})}
+			aria-hidden="true"
+		>
+			<path
+				fillRule="evenodd"
+				d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z"
+				clipRule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+/**
  * アカウントアイコン（SVG）
  */
 function AccountIcon() {
@@ -251,24 +276,33 @@ export function EventCard({ event, color }: EventCardProps) {
 					</div>
 				)}
 
-				{/* アカウント情報（メールアドレス） */}
-				{event.source.accountEmail && (
-					<div
-						className={css({
-							display: "flex",
-							alignItems: "center",
-							gap: "1.5",
-							mt: "1.5",
-							color: "#78716c",
-							fontSize: "xs",
-						})}
-					>
-						<AccountIcon />
-						<span className={css({ truncate: true })}>
-							{event.source.accountEmail}
-						</span>
-					</div>
-				)}
+				{/* カレンダー情報（Google: メールアドレス、iCal: カレンダー名） */}
+				<div
+					className={css({
+						display: "flex",
+						alignItems: "center",
+						gap: "1.5",
+						mt: "1.5",
+						color: "#78716c",
+						fontSize: "xs",
+					})}
+				>
+					{event.source.accountEmail ? (
+						<>
+							<AccountIcon />
+							<span className={css({ truncate: true })}>
+								{event.source.accountEmail}
+							</span>
+						</>
+					) : (
+						<>
+							<CalendarSourceIcon />
+							<span className={css({ truncate: true })}>
+								{event.source.calendarName}
+							</span>
+						</>
+					)}
+				</div>
 			</div>
 		</article>
 	);


### PR DESCRIPTION
## Summary

- iCalイベントにカレンダー名を表示するように修正
- Google予定はメールアドレス、iCal予定はカレンダー名で識別可能に

## 変更内容

- EventCard: カレンダー情報の表示ロジックを変更
  - Google: メールアイコン + accountEmail
  - iCal: カレンダーアイコン + calendarName
- CalendarSourceIconを追加

## Test plan

- [ ] Google予定にメールアドレスが表示される
- [ ] iCal予定にカレンダー名が表示される