### PR TITLE
今日の予定表示をタイムライン形式に変更

### DIFF
--- a/components/calendar/CurrentTimeIndicator.tsx
+++ b/components/calendar/CurrentTimeIndicator.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+/**
+ * CurrentTimeIndicatorコンポーネント
+ *
+ * カレンダービューで現在時刻を示す赤いラインと時刻バッジを表示するコンポーネントです。
+ * 1日の表示範囲に対する相対位置を計算し、適切な位置に配置されます。
+ *
+ * @module components/calendar/CurrentTimeIndicator
+ *
+ * @example
+ * ```tsx
+ * <CurrentTimeIndicator
+ *   currentTime={new Date()}
+ *   dayStartHour={6}
+ *   dayEndHour={22}
+ * />
+ * ```
+ */
+
+import { css } from "@/styled-system/css";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/**
+ * CurrentTimeIndicatorコンポーネントのProps
+ */
+interface CurrentTimeIndicatorProps {
+	/** 現在時刻 */
+	currentTime: Date;
+	/** 1日の開始時刻（デフォルト: 0時） */
+	dayStartHour?: number;
+	/** 1日の終了時刻（デフォルト: 24時） */
+	dayEndHour?: number;
+}
+
+// ============================================================
+// 定数
+// ============================================================
+
+/**
+ * 赤色（Tailwind red-500相当）
+ */
+const RED_COLOR = "#ef4444";
+
+/**
+ * デフォルトの1日の開始時刻
+ */
+const DEFAULT_DAY_START_HOUR = 0;
+
+/**
+ * デフォルトの1日の終了時刻
+ */
+const DEFAULT_DAY_END_HOUR = 24;
+
+// ============================================================
+// ユーティリティ関数
+// ============================================================
+
+/**
+ * 現在時刻をJSTの"HH:mm"形式でフォーマット
+ *
+ * @param date - フォーマット対象の日時
+ * @returns "HH:mm"形式の文字列
+ */
+function formatTimeJST(date: Date): string {
+	return new Intl.DateTimeFormat("ja-JP", {
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+		timeZone: "Asia/Tokyo",
+	}).format(date);
+}
+
+/**
+ * 1日の時間範囲に対する相対位置（%）を計算
+ *
+ * @param currentTime - 現在時刻
+ * @param dayStartHour - 1日の開始時刻
+ * @param dayEndHour - 1日の終了時刻
+ * @returns 相対位置（0-100の範囲、範囲外の場合は null）
+ */
+function calculateTopPosition(
+	currentTime: Date,
+	dayStartHour: number,
+	dayEndHour: number,
+): number | null {
+	// JSTでの時間・分を取得
+	const hours = currentTime.getHours();
+	const minutes = currentTime.getMinutes();
+
+	// 1日の時間範囲に対する相対位置（%）
+	const totalMinutes = hours * 60 + minutes;
+	const dayStartMinutes = dayStartHour * 60;
+	const dayEndMinutes = dayEndHour * 60;
+
+	// 表示範囲外の場合は null を返す
+	if (totalMinutes < dayStartMinutes || totalMinutes > dayEndMinutes) {
+		return null;
+	}
+
+	const top =
+		((totalMinutes - dayStartMinutes) / (dayEndMinutes - dayStartMinutes)) *
+		100;
+	return top;
+}
+
+// ============================================================
+// メインコンポーネント
+// ============================================================
+
+/**
+ * コンテナスタイル
+ */
+const containerStyle = css({
+	position: "absolute",
+	left: 0,
+	right: 0,
+	display: "flex",
+	alignItems: "center",
+	zIndex: 10,
+	pointerEvents: "none",
+});
+
+/**
+ * 時刻バッジスタイル
+ */
+const badgeStyle = css({
+	px: "2",
+	py: "1",
+	fontSize: "xs",
+	fontWeight: "medium",
+	color: "white",
+	borderRadius: "md",
+	flexShrink: 0,
+});
+
+/**
+ * 赤いラインスタイル
+ */
+const lineStyle = css({
+	flex: 1,
+	height: "2px",
+});
+
+/**
+ * 現在時刻インジケーターコンポーネント
+ *
+ * カレンダービューで現在時刻を示す赤いラインと時刻バッジを表示します。
+ * 親要素は position: relative である必要があります。
+ *
+ * @param props - コンポーネントのProps
+ * @param props.currentTime - 現在時刻
+ * @param props.dayStartHour - 1日の開始時刻（オプション、デフォルト: 0）
+ * @param props.dayEndHour - 1日の終了時刻（オプション、デフォルト: 24）
+ * @returns 現在時刻インジケーター要素、または範囲外の場合は null
+ */
+export function CurrentTimeIndicator({
+	currentTime,
+	dayStartHour = DEFAULT_DAY_START_HOUR,
+	dayEndHour = DEFAULT_DAY_END_HOUR,
+}: CurrentTimeIndicatorProps) {
+	// 相対位置を計算
+	const topPosition = calculateTopPosition(
+		currentTime,
+		dayStartHour,
+		dayEndHour,
+	);
+
+	// 表示範囲外の場合は何も表示しない
+	if (topPosition === null) {
+		return null;
+	}
+
+	// 時刻表示文字列
+	const timeDisplay = formatTimeJST(currentTime);
+
+	return (
+		<div
+			className={containerStyle}
+			style={{ top: `${topPosition}%` }}
+			role="presentation"
+			aria-label={`現在時刻: ${timeDisplay}`}
+		>
+			{/* 時刻バッジ（左端） */}
+			<span className={badgeStyle} style={{ backgroundColor: RED_COLOR }}>
+				{timeDisplay}
+			</span>
+
+			{/* 赤いライン */}
+			<div
+				className={lineStyle}
+				style={{ backgroundColor: RED_COLOR }}
+				aria-hidden="true"
+			/>
+		</div>
+	);
+}

--- a/components/calendar/TimelineEvent.tsx
+++ b/components/calendar/TimelineEvent.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+/**
+ * TimelineEventコンポーネント
+ *
+ * タイムライン上に表示する個別のカレンダーイベントコンポーネントです。
+ * イベントのステータス（past/current/next/future）に応じたスタイルを適用し、
+ * 時間、タイトル、場所を表示します。
+ *
+ * @module components/calendar/TimelineEvent
+ *
+ * @example
+ * ```tsx
+ * <TimelineEvent
+ *   event={{
+ *     id: "1",
+ *     title: "ミーティング",
+ *     startTime: "2026-01-27T09:00:00+09:00",
+ *     endTime: "2026-01-27T10:00:00+09:00",
+ *     isAllDay: false,
+ *     location: "会議室A",
+ *     source: { type: "google", calendarName: "仕事" },
+ *     color: "#4285f4",
+ *     column: 0,
+ *     totalColumns: 1,
+ *     status: "current"
+ *   }}
+ *   dayStart="2026-01-27T00:00:00+09:00"
+ *   dayEnd="2026-01-28T00:00:00+09:00"
+ * />
+ * ```
+ */
+
+import { formatTime } from "@/lib/utils/date";
+import {
+	calculateEventPosition,
+	type EventStatus,
+	type TimelineEvent as TimelineEventType,
+} from "@/lib/utils/timeline";
+import { css, cx } from "@/styled-system/css";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/**
+ * TimelineEventコンポーネントのProps
+ */
+interface TimelineEventProps {
+	/** イベントデータ */
+	event: TimelineEventType;
+	/** 1日の開始時刻（ISO 8601形式） */
+	dayStart: string;
+	/** 1日の終了時刻（ISO 8601形式） */
+	dayEnd: string;
+}
+
+// ============================================================
+// 定数
+// ============================================================
+
+/**
+ * デフォルトのカレンダー色
+ */
+const DEFAULT_COLOR = "#6b7280";
+
+/**
+ * 列間のギャップ（px）
+ */
+const COLUMN_GAP = 2;
+
+/**
+ * ステータス別のスタイル設定
+ */
+const STATUS_STYLES: Record<
+	EventStatus,
+	{ backgroundColor: string; opacity: number }
+> = {
+	past: { backgroundColor: "#f3f4f6", opacity: 0.5 },
+	current: { backgroundColor: "#fef3c7", opacity: 1 },
+	next: { backgroundColor: "#dbeafe", opacity: 1 },
+	future: { backgroundColor: "#ffffff", opacity: 1 },
+};
+
+/**
+ * バッジ設定
+ */
+const BADGE_CONFIG: Record<
+	"current" | "next",
+	{ text: string; backgroundColor: string; color: string }
+> = {
+	current: { text: "NOW", backgroundColor: "#dc2626", color: "#ffffff" },
+	next: { text: "NEXT", backgroundColor: "#2563eb", color: "#ffffff" },
+};
+
+// ============================================================
+// サブコンポーネント
+// ============================================================
+
+/**
+ * カレンダーソースアイコン（SVG）- iCal用
+ */
+function CalendarSourceIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			className={css({
+				width: "3",
+				height: "3",
+				flexShrink: 0,
+			})}
+			aria-hidden="true"
+		>
+			<path
+				fillRule="evenodd"
+				d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z"
+				clipRule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+/**
+ * アカウントアイコン（SVG）
+ */
+function AccountIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			className={css({
+				width: "3",
+				height: "3",
+				flexShrink: 0,
+			})}
+			aria-hidden="true"
+		>
+			<path d="M3 4a2 2 0 00-2 2v1.161l8.441 4.221a1.25 1.25 0 001.118 0L19 7.162V6a2 2 0 00-2-2H3z" />
+			<path d="M19 8.839l-7.77 3.885a2.75 2.75 0 01-2.46 0L1 8.839V14a2 2 0 002 2h14a2 2 0 002-2V8.839z" />
+		</svg>
+	);
+}
+
+/**
+ * 場所アイコン（SVG）
+ */
+function LocationIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			className={css({
+				width: "3",
+				height: "3",
+				flexShrink: 0,
+			})}
+			aria-hidden="true"
+		>
+			<path
+				fillRule="evenodd"
+				d="M9.69 18.933l.003.001C9.89 19.02 10 19 10 19s.11.02.308-.066l.002-.001.006-.003.018-.008a5.741 5.741 0 00.281-.14c.186-.096.446-.24.757-.433.62-.384 1.445-.966 2.274-1.765C15.302 14.988 17 12.493 17 9A7 7 0 103 9c0 3.492 1.698 5.988 3.355 7.584a13.731 13.731 0 002.273 1.765 11.842 11.842 0 00.976.544l.062.029.018.008.006.003zM10 11.25a2.25 2.25 0 100-4.5 2.25 2.25 0 000 4.5z"
+				clipRule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+/**
+ * ステータスバッジコンポーネント
+ *
+ * currentまたはnextステータスの場合にバッジを表示します。
+ *
+ * @param props - コンポーネントのProps
+ * @param props.status - イベントのステータス
+ * @returns バッジ要素、またはnull
+ */
+function StatusBadge({ status }: { status: EventStatus }) {
+	// pastとfutureにはバッジを表示しない
+	if (status !== "current" && status !== "next") {
+		return null;
+	}
+
+	const config = BADGE_CONFIG[status];
+
+	return (
+		<span
+			className={css({
+				position: "absolute",
+				top: "1",
+				right: "1",
+				fontSize: "10px",
+				fontWeight: "bold",
+				px: "1.5",
+				py: "0.5",
+				borderRadius: "full",
+				lineHeight: 1,
+			})}
+			style={{
+				backgroundColor: config.backgroundColor,
+				color: config.color,
+			}}
+		>
+			{config.text}
+		</span>
+	);
+}
+
+// ============================================================
+// メインコンポーネント
+// ============================================================
+
+/**
+ * 基本カードスタイル
+ */
+const baseCardStyle = css({
+	position: "absolute",
+	display: "flex",
+	alignItems: "stretch",
+	gap: "2",
+	pl: "2",
+	pr: "2",
+	pt: "2",
+	pb: "2",
+	borderRadius: "md",
+	border: "1px solid",
+	borderColor: "border.default",
+	boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
+	overflow: "hidden",
+	cursor: "pointer",
+	transition: "box-shadow 0.15s ease-in-out",
+	_hover: {
+		boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+	},
+});
+
+/**
+ * タイムラインイベントコンポーネント
+ *
+ * タイムライン上に配置される個別のイベントを表示します。
+ * ステータスに応じた背景色とバッジを適用し、
+ * 時間・タイトル・場所を表示します。
+ *
+ * @param props - コンポーネントのProps
+ * @param props.event - イベントデータ
+ * @param props.dayStart - 1日の開始時刻
+ * @param props.dayEnd - 1日の終了時刻
+ * @returns タイムラインイベント要素
+ */
+export function TimelineEvent({ event, dayStart, dayEnd }: TimelineEventProps) {
+	const calendarColor = event.color ?? DEFAULT_COLOR;
+	const statusStyle = STATUS_STYLES[event.status];
+
+	// イベントの位置を計算
+	const position = calculateEventPosition(
+		event.startTime,
+		event.endTime,
+		dayStart,
+		dayEnd,
+	);
+
+	// 列に基づく水平位置を計算（横いっぱいに広がるように）
+	// 3つ重なっていれば各カードは33.3%ずつ
+	// ギャップはカード間のみ（totalColumns - 1箇所）
+	const totalGap = (event.totalColumns - 1) * COLUMN_GAP;
+	const cardWidth = `calc((100% - ${totalGap}px) / ${event.totalColumns})`;
+	const cardLeft = `calc((100% - ${totalGap}px) / ${event.totalColumns} * ${event.column} + ${event.column * COLUMN_GAP}px)`;
+
+	// 時間表示を生成
+	const timeDisplay = `${formatTime(event.startTime)} - ${formatTime(event.endTime)}`;
+
+	return (
+		<article
+			className={cx(baseCardStyle)}
+			style={{
+				top: `${position.top}%`,
+				height: `${position.height}%`,
+				minHeight: "70px",
+				left: cardLeft,
+				width: cardWidth,
+				backgroundColor: statusStyle.backgroundColor,
+				opacity: statusStyle.opacity,
+			}}
+		>
+			{/* イベント情報（縦バーを内包） */}
+			<div
+				className={css({
+					flex: 1,
+					minWidth: 0,
+					position: "relative",
+					display: "flex",
+					gap: "2",
+				})}
+			>
+				{/* カレンダー色バー（コンテンツと同じ高さ） */}
+				<div
+					className={css({
+						width: "3px",
+						borderRadius: "full",
+						flexShrink: 0,
+						alignSelf: "stretch",
+					})}
+					style={{ backgroundColor: calendarColor }}
+					aria-hidden="true"
+				/>
+
+				{/* テキストコンテンツ */}
+				<div className={css({ flex: 1, minWidth: 0 })}>
+					{/* ステータスバッジ */}
+					<StatusBadge status={event.status} />
+
+					{/* 時間表示 */}
+					<time
+						className={css({
+							display: "block",
+							fontSize: "xs",
+							fontWeight: "medium",
+							color: "fg.muted",
+							lineHeight: "tight",
+						})}
+						dateTime={event.startTime}
+					>
+						{timeDisplay}
+					</time>
+
+					{/* タイトル（1行、truncate） */}
+					<h3
+						className={css({
+							fontSize: "sm",
+							fontWeight: "semibold",
+							color: "fg.default",
+							truncate: true,
+							lineHeight: "snug",
+							mt: "0.5",
+							pr: "10",
+						})}
+					>
+						{event.title}
+					</h3>
+
+					{/* 場所（存在する場合のみ、1行、truncate） */}
+					{event.location && (
+						<div
+							className={css({
+								display: "flex",
+								alignItems: "center",
+								gap: "1",
+								mt: "1",
+								color: "fg.muted",
+								fontSize: "xs",
+							})}
+						>
+							<LocationIcon />
+							<span className={css({ truncate: true })}>{event.location}</span>
+						</div>
+					)}
+
+					{/* カレンダー情報（Google: メールアドレス、iCal: カレンダー名） */}
+					<div
+						className={css({
+							display: "flex",
+							alignItems: "center",
+							gap: "1",
+							mt: "0.5",
+							color: "fg.muted",
+							fontSize: "xs",
+						})}
+					>
+						{event.source.accountEmail ? (
+							<>
+								<AccountIcon />
+								<span className={css({ truncate: true })}>
+									{event.source.accountEmail}
+								</span>
+							</>
+						) : (
+							<>
+								<CalendarSourceIcon />
+								<span className={css({ truncate: true })}>
+									{event.source.calendarName}
+								</span>
+							</>
+						)}
+					</div>
+				</div>
+			</div>
+		</article>
+	);
+}

--- a/components/calendar/TimelineView.tsx
+++ b/components/calendar/TimelineView.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+/**
+ * TimelineViewコンポーネント
+ *
+ * タイムライン形式でイベントを表示するメインコンポーネントです。
+ * 終日イベントと時間指定イベントを分離し、視覚的なタイムライン上に配置します。
+ *
+ * @module components/calendar/TimelineView
+ *
+ * @example
+ * ```tsx
+ * <TimelineView
+ *   events={calendarEvents}
+ *   currentTime={new Date()}
+ *   dayStartHour={6}
+ *   dayEndHour={22}
+ * />
+ * ```
+ */
+
+import { type InputEvent, prepareTimelineEvents } from "@/lib/utils/timeline";
+import { css } from "@/styled-system/css";
+import { CurrentTimeIndicator } from "./CurrentTimeIndicator";
+import { EventCard } from "./EventCard";
+import { TimelineEvent } from "./TimelineEvent";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/**
+ * TimelineViewコンポーネントのProps
+ */
+export interface TimelineViewProps {
+	/** イベント一覧 */
+	events: InputEvent[];
+	/** 現在時刻 */
+	currentTime: Date;
+	/** 1日の開始時刻（デフォルト: 6時） */
+	dayStartHour?: number;
+	/** 1日の終了時刻（デフォルト: 22時） */
+	dayEndHour?: number;
+}
+
+// ============================================================
+// 定数
+// ============================================================
+
+/**
+ * デフォルトの1日の開始時刻
+ */
+const DEFAULT_DAY_START_HOUR = 6;
+
+/**
+ * デフォルトの1日の終了時刻
+ */
+const DEFAULT_DAY_END_HOUR = 22;
+
+/**
+ * 1時間あたりの高さ（px）
+ * 30分イベントでも最低70pxの高さを確保するため、140pxに設定
+ */
+const HOUR_HEIGHT = 140;
+
+/**
+ * 時刻ラベルの幅（px）
+ */
+const TIME_LABEL_WIDTH = 60;
+
+// ============================================================
+// ユーティリティ関数
+// ============================================================
+
+/**
+ * 今日の日付と指定時刻からISO 8601形式の日時文字列を生成
+ *
+ * @param currentTime - 基準となる現在時刻
+ * @param hour - 時刻（0-24）
+ * @returns ISO 8601形式の日時文字列
+ */
+function createDayTimeISO(currentTime: Date, hour: number): string {
+	const date = new Date(currentTime);
+	date.setHours(hour, 0, 0, 0);
+	return date.toISOString();
+}
+
+/**
+ * 時刻ラベルを生成
+ *
+ * @param hour - 時刻（0-24）
+ * @returns "HH:00"形式の文字列
+ */
+function formatHourLabel(hour: number): string {
+	return `${hour.toString().padStart(2, "0")}:00`;
+}
+
+// ============================================================
+// サブコンポーネント
+// ============================================================
+
+/**
+ * 終日イベントセクション
+ *
+ * 終日イベントがある場合のみ表示されるセクションです。
+ *
+ * @param props - コンポーネントのProps
+ * @param props.events - 終日イベントの配列
+ * @returns 終日イベントセクション要素、またはnull
+ */
+function AllDaySection({ events }: { events: InputEvent[] }) {
+	if (events.length === 0) {
+		return null;
+	}
+
+	return (
+		<section
+			className={css({
+				display: "flex",
+				flexDirection: "column",
+				gap: "2",
+				pb: "4",
+				mb: "4",
+				borderBottom: "1px solid",
+				borderColor: "border.subtle",
+			})}
+			aria-label="終日イベント"
+		>
+			<h3
+				className={css({
+					fontSize: "xs",
+					fontWeight: "medium",
+					color: "fg.muted",
+					m: "0",
+				})}
+			>
+				終日
+			</h3>
+			<div
+				className={css({
+					display: "flex",
+					flexDirection: "column",
+					gap: "2",
+				})}
+			>
+				{events.map((event) => (
+					<EventCard key={event.id} event={event} color={event.color} />
+				))}
+			</div>
+		</section>
+	);
+}
+
+/**
+ * 時刻グリッドコンポーネント
+ *
+ * 時刻ラベルと横線を表示するグリッドです。
+ *
+ * @param props - コンポーネントのProps
+ * @param props.startHour - 開始時刻
+ * @param props.endHour - 終了時刻
+ * @returns 時刻グリッド要素
+ */
+function TimeGrid({
+	startHour,
+	endHour,
+}: {
+	startHour: number;
+	endHour: number;
+}) {
+	const hours = [];
+	for (let hour = startHour; hour <= endHour; hour++) {
+		hours.push(hour);
+	}
+
+	return (
+		<div
+			className={css({
+				position: "absolute",
+				top: 0,
+				left: 0,
+				right: 0,
+				bottom: 0,
+				pointerEvents: "none",
+			})}
+			aria-hidden="true"
+		>
+			{hours.map((hour, index) => (
+				<div
+					key={hour}
+					className={css({
+						position: "absolute",
+						left: 0,
+						right: 0,
+						display: "flex",
+						alignItems: "flex-start",
+					})}
+					style={{
+						top: `${index * HOUR_HEIGHT}px`,
+						height: `${HOUR_HEIGHT}px`,
+					}}
+				>
+					{/* 時刻ラベル */}
+					<span
+						className={css({
+							fontSize: "xs",
+							color: "fg.muted",
+							textAlign: "right",
+							pr: "3",
+							flexShrink: 0,
+							transform: "translateY(-50%)",
+						})}
+						style={{ width: `${TIME_LABEL_WIDTH}px` }}
+					>
+						{formatHourLabel(hour)}
+					</span>
+					{/* 横線 */}
+					<div
+						className={css({
+							flex: 1,
+							borderTop: "1px solid",
+							borderColor: "border.subtle",
+						})}
+					/>
+				</div>
+			))}
+		</div>
+	);
+}
+
+// ============================================================
+// メインコンポーネント
+// ============================================================
+
+/**
+ * タイムラインビューコンポーネント
+ *
+ * タイムライン形式でカレンダーイベントを表示します。
+ * 終日イベントは上部に、時間指定イベントはタイムラインに配置されます。
+ *
+ * @param props - コンポーネントのProps
+ * @param props.events - イベント一覧
+ * @param props.currentTime - 現在時刻
+ * @param props.dayStartHour - 1日の開始時刻（オプション、デフォルト: 6）
+ * @param props.dayEndHour - 1日の終了時刻（オプション、デフォルト: 22）
+ * @returns タイムラインビュー要素
+ */
+export function TimelineView({
+	events,
+	currentTime,
+	dayStartHour = DEFAULT_DAY_START_HOUR,
+	dayEndHour = DEFAULT_DAY_END_HOUR,
+}: TimelineViewProps) {
+	// タイムライン表示用にイベントを準備
+	const { allDayEvents, timedEvents } = prepareTimelineEvents(
+		events,
+		currentTime,
+	);
+
+	// 日時文字列を生成
+	const dayStart = createDayTimeISO(currentTime, dayStartHour);
+	const dayEnd = createDayTimeISO(currentTime, dayEndHour);
+
+	// 表示時間帯の計算
+	const displayHours = dayEndHour - dayStartHour;
+	const totalHeight = displayHours * HOUR_HEIGHT;
+
+	return (
+		<div
+			className={css({
+				display: "flex",
+				flexDirection: "column",
+				width: "100%",
+			})}
+		>
+			{/* 終日イベントセクション */}
+			<AllDaySection events={allDayEvents} />
+
+			{/* タイムライングリッド */}
+			<div
+				className={css({
+					position: "relative",
+					width: "100%",
+				})}
+				style={{ height: `${totalHeight}px` }}
+			>
+				{/* 時刻グリッド（背景） */}
+				<TimeGrid startHour={dayStartHour} endHour={dayEndHour} />
+
+				{/* イベント表示エリア */}
+				<div
+					className={css({
+						position: "absolute",
+						top: 0,
+						bottom: 0,
+						right: 0,
+					})}
+					style={{
+						left: `${TIME_LABEL_WIDTH}px`,
+					}}
+				>
+					{/* 現在時刻インジケーター */}
+					<CurrentTimeIndicator
+						currentTime={currentTime}
+						dayStartHour={dayStartHour}
+						dayEndHour={dayEndHour}
+					/>
+
+					{/* タイムラインイベント */}
+					{timedEvents.map((event) => (
+						<TimelineEvent
+							key={event.id}
+							event={event}
+							dayStart={dayStart}
+							dayEnd={dayEnd}
+						/>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/components/calendar/TodayView.tsx
+++ b/components/calendar/TodayView.tsx
@@ -20,8 +20,10 @@
  * ```
  */
 
+import { useCurrentTime } from "@/hooks/useCurrentTime";
+import type { InputEvent } from "@/lib/utils/timeline";
 import { css, cx } from "@/styled-system/css";
-import { type CalendarEvent, EventList } from "./EventList";
+import { TimelineView } from "./TimelineView";
 
 // ============================================================
 // 型定義
@@ -32,7 +34,7 @@ import { type CalendarEvent, EventList } from "./EventList";
  */
 export interface TodayViewProps {
 	/** 今日の予定一覧 */
-	events: CalendarEvent[];
+	events: InputEvent[];
 	/** ローディング状態 */
 	isLoading: boolean;
 	/** エラー情報 */
@@ -466,6 +468,9 @@ export function TodayView({
 	onRefresh,
 	lastSync,
 }: TodayViewProps) {
+	// 現在時刻をリアルタイムで取得
+	const currentTime = useCurrentTime();
+
 	return (
 		<section
 			className={css({
@@ -544,7 +549,7 @@ export function TodayView({
 				) : events.length === 0 ? (
 					<EmptyState />
 				) : (
-					<EventList events={events} emptyMessage="今日の予定はありません" />
+					<TimelineView events={events} currentTime={currentTime} />
 				)}
 			</div>
 		</section>

--- a/hooks/useCurrentTime.ts
+++ b/hooks/useCurrentTime.ts
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * 現在時刻フック
+ *
+ * 現在時刻をリアルタイムで提供し、60秒間隔で更新します。
+ * 分の境界に同期することで、時計表示などに最適化されています。
+ *
+ * @module hooks/useCurrentTime
+ *
+ * @example
+ * ```tsx
+ * const currentTime = useCurrentTime();
+ *
+ * return (
+ *   <div>
+ *     現在時刻: {currentTime.toLocaleTimeString()}
+ *   </div>
+ * );
+ * ```
+ */
+
+import { useEffect, useState } from "react";
+
+/**
+ * 現在時刻をリアルタイムで提供するフック
+ *
+ * 60秒間隔で更新し、分の境界に同期します。
+ * 例: 10:30:45の場合、次の更新は10:31:00に行われます。
+ *
+ * @returns 現在時刻のDateオブジェクト
+ *
+ * @example
+ * ```tsx
+ * function Clock() {
+ *   const currentTime = useCurrentTime();
+ *
+ *   return (
+ *     <time dateTime={currentTime.toISOString()}>
+ *       {currentTime.toLocaleTimeString('ja-JP', {
+ *         hour: '2-digit',
+ *         minute: '2-digit'
+ *       })}
+ *     </time>
+ *   );
+ * }
+ * ```
+ */
+export function useCurrentTime(): Date {
+	const [currentTime, setCurrentTime] = useState<Date>(() => new Date());
+
+	useEffect(() => {
+		// インターバルIDを保持する変数
+		let intervalId: ReturnType<typeof setInterval> | null = null;
+
+		// 次の分までの残りミリ秒を計算
+		const now = new Date();
+		const msUntilNextMinute =
+			(60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+
+		// 最初のタイムアウトで分境界に同期
+		const timeoutId = setTimeout(() => {
+			setCurrentTime(new Date());
+
+			// その後は60秒間隔で更新
+			intervalId = setInterval(() => {
+				setCurrentTime(new Date());
+			}, 60000);
+		}, msUntilNextMinute);
+
+		// クリーンアップ: タイムアウトとインターバルの両方をクリア
+		return () => {
+			clearTimeout(timeoutId);
+			if (intervalId !== null) {
+				clearInterval(intervalId);
+			}
+		};
+	}, []);
+
+	return currentTime;
+}

--- a/lib/utils/timeline.ts
+++ b/lib/utils/timeline.ts
@@ -1,0 +1,467 @@
+/**
+ * タイムラインユーティリティモジュール
+ *
+ * このモジュールはカレンダーのタイムライン表示に必要な機能を提供します。
+ * - eventsOverlap: 2つのイベントの時間重複判定
+ * - assignColumns: 重複イベントへの列割り当て
+ * - getEventStatus: イベントのステータス判定
+ * - calculateEventPosition: イベントの位置計算
+ * - prepareTimelineEvents: タイムライン表示用のイベント変換
+ *
+ * すべての関数は純粋関数として実装されています。
+ *
+ * @module lib/utils/timeline
+ */
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/**
+ * イベントのステータス
+ * - past: 終了済み
+ * - current: 現在進行中
+ * - next: 次のイベント（未来イベントの中で最初のもの）
+ * - future: 将来のイベント
+ */
+export type EventStatus = "past" | "current" | "next" | "future";
+
+/**
+ * タイムライン表示用のイベント
+ */
+export interface TimelineEvent {
+	/** イベントの一意識別子 */
+	id: string;
+	/** イベントのタイトル */
+	title: string;
+	/** 開始時刻（ISO 8601形式） */
+	startTime: string;
+	/** 終了時刻（ISO 8601形式） */
+	endTime: string;
+	/** 終日イベントかどうか */
+	isAllDay: boolean;
+	/** 場所（nullの場合は未設定） */
+	location: string | null;
+	/** イベントのソース情報 */
+	source: {
+		/** カレンダーの種類 */
+		type: "google" | "ical";
+		/** カレンダー名 */
+		calendarName: string;
+		/** アカウントのメールアドレス（Googleの場合） */
+		accountEmail?: string;
+	};
+	/** 表示色（オプション） */
+	color?: string;
+	/** タイムライン配置用: 列番号（0始まり） */
+	column: number;
+	/** タイムライン配置用: 合計列数 */
+	totalColumns: number;
+	/** イベントのステータス */
+	status: EventStatus;
+}
+
+/**
+ * イベントの位置情報
+ */
+export interface EventPosition {
+	/** 上端の位置（%） */
+	top: number;
+	/** 高さ（%） */
+	height: number;
+}
+
+/**
+ * 入力イベントの型（TimelineEventから配置情報を除いたもの）
+ */
+export type InputEvent = Omit<
+	TimelineEvent,
+	"column" | "totalColumns" | "status"
+>;
+
+// ============================================================
+// eventsOverlap - 2つのイベントの時間重複判定
+// ============================================================
+
+/**
+ * 2つのイベントが時間的に重複しているかを判定します
+ *
+ * 重複条件: A開始 < B終了 かつ B開始 < A終了
+ * 境界が一致する場合（A終了 = B開始）は重複とみなしません。
+ *
+ * @param eventA - 比較対象のイベントA
+ * @param eventB - 比較対象のイベントB
+ * @returns 重複している場合true、それ以外はfalse
+ *
+ * @example
+ * ```typescript
+ * // 重複あり: 9:00-10:00 と 9:30-10:30
+ * eventsOverlap(
+ *   { startTime: "2026-01-27T09:00:00Z", endTime: "2026-01-27T10:00:00Z", ... },
+ *   { startTime: "2026-01-27T09:30:00Z", endTime: "2026-01-27T10:30:00Z", ... }
+ * ); // true
+ *
+ * // 重複なし: 9:00-10:00 と 10:00-11:00（境界一致）
+ * eventsOverlap(
+ *   { startTime: "2026-01-27T09:00:00Z", endTime: "2026-01-27T10:00:00Z", ... },
+ *   { startTime: "2026-01-27T10:00:00Z", endTime: "2026-01-27T11:00:00Z", ... }
+ * ); // false
+ * ```
+ */
+export function eventsOverlap(
+	eventA: Pick<InputEvent, "startTime" | "endTime">,
+	eventB: Pick<InputEvent, "startTime" | "endTime">,
+): boolean {
+	const aStart = new Date(eventA.startTime).getTime();
+	const aEnd = new Date(eventA.endTime).getTime();
+	const bStart = new Date(eventB.startTime).getTime();
+	const bEnd = new Date(eventB.endTime).getTime();
+
+	// A開始 < B終了 かつ B開始 < A終了
+	return aStart < bEnd && bStart < aEnd;
+}
+
+// ============================================================
+// assignColumns - 重複イベントへの列割り当て
+// ============================================================
+
+/**
+ * 列割り当て結果の型
+ */
+interface ColumnAssignment {
+	/** イベントID */
+	id: string;
+	/** 割り当てられた列番号（0始まり） */
+	column: number;
+}
+
+/**
+ * 重複するイベントに列を割り当てます（貪欲法）
+ *
+ * 開始時刻でソートし、各イベントを「重複しない最小の列」に配置します。
+ * 各列の終了時刻を追跡して、新しいイベントがどの列に配置可能かを判定します。
+ *
+ * @param events - 列を割り当てるイベントの配列
+ * @returns イベントIDと列番号のマッピング配列
+ *
+ * @example
+ * ```typescript
+ * const events = [
+ *   { id: "1", startTime: "2026-01-27T09:00:00Z", endTime: "2026-01-27T10:00:00Z", ... },
+ *   { id: "2", startTime: "2026-01-27T09:30:00Z", endTime: "2026-01-27T10:30:00Z", ... },
+ *   { id: "3", startTime: "2026-01-27T10:00:00Z", endTime: "2026-01-27T11:00:00Z", ... },
+ * ];
+ * assignColumns(events);
+ * // [{ id: "1", column: 0 }, { id: "2", column: 1 }, { id: "3", column: 0 }]
+ * ```
+ */
+export function assignColumns(
+	events: ReadonlyArray<Pick<InputEvent, "id" | "startTime" | "endTime">>,
+): ColumnAssignment[] {
+	if (events.length === 0) {
+		return [];
+	}
+
+	// 開始時刻でソート
+	const sortedEvents = [...events].sort(
+		(a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+	);
+
+	// 各列の終了時刻を追跡（列番号 -> 終了時刻のタイムスタンプ）
+	const columnEndTimes: number[] = [];
+	const assignments: ColumnAssignment[] = [];
+
+	for (const event of sortedEvents) {
+		const eventStart = new Date(event.startTime).getTime();
+		const eventEnd = new Date(event.endTime).getTime();
+
+		// 重複しない最小の列を探す
+		let assignedColumn = -1;
+		for (let col = 0; col < columnEndTimes.length; col++) {
+			if (columnEndTimes[col] <= eventStart) {
+				assignedColumn = col;
+				break;
+			}
+		}
+
+		// 既存の列に配置できない場合は新しい列を追加
+		if (assignedColumn === -1) {
+			assignedColumn = columnEndTimes.length;
+			columnEndTimes.push(eventEnd);
+		} else {
+			columnEndTimes[assignedColumn] = eventEnd;
+		}
+
+		assignments.push({ id: event.id, column: assignedColumn });
+	}
+
+	return assignments;
+}
+
+// ============================================================
+// getEventStatus - イベントのステータス判定
+// ============================================================
+
+/**
+ * イベントのステータスを判定します
+ *
+ * - past: 終了時刻 ≤ 現在時刻
+ * - current: 開始時刻 ≤ 現在時刻 < 終了時刻
+ * - next: 現在時刻 < 開始時刻（未来イベントの中で最初のもの）
+ * - future: 現在時刻 < 開始時刻（nextイベント以外）
+ *
+ * 注意: この関数は単一イベントのステータスを判定します。
+ * "next"と"future"の区別は呼び出し側で行う必要があります。
+ * 未来イベントの場合、この関数は"future"を返します。
+ *
+ * @param event - ステータスを判定するイベント
+ * @param now - 現在時刻
+ * @returns イベントのステータス（"past", "current", または "future"）
+ *
+ * @example
+ * ```typescript
+ * const now = new Date("2026-01-27T10:00:00Z");
+ *
+ * // 過去のイベント
+ * getEventStatus(
+ *   { startTime: "2026-01-27T08:00:00Z", endTime: "2026-01-27T09:00:00Z", ... },
+ *   now
+ * ); // "past"
+ *
+ * // 現在進行中のイベント
+ * getEventStatus(
+ *   { startTime: "2026-01-27T09:30:00Z", endTime: "2026-01-27T10:30:00Z", ... },
+ *   now
+ * ); // "current"
+ *
+ * // 未来のイベント
+ * getEventStatus(
+ *   { startTime: "2026-01-27T11:00:00Z", endTime: "2026-01-27T12:00:00Z", ... },
+ *   now
+ * ); // "future"
+ * ```
+ */
+export function getEventStatus(
+	event: Pick<InputEvent, "startTime" | "endTime">,
+	now: Date,
+): Exclude<EventStatus, "next"> {
+	const eventStart = new Date(event.startTime).getTime();
+	const eventEnd = new Date(event.endTime).getTime();
+	const nowTime = now.getTime();
+
+	if (eventEnd <= nowTime) {
+		return "past";
+	}
+
+	if (eventStart <= nowTime && nowTime < eventEnd) {
+		return "current";
+	}
+
+	return "future";
+}
+
+// ============================================================
+// calculateEventPosition - イベントの位置計算
+// ============================================================
+
+/**
+ * イベントの表示位置を計算します
+ *
+ * 1日の時間範囲に対するイベントの相対位置（%）を計算します。
+ * イベントが1日の範囲をはみ出す場合は、範囲内にクリップされます。
+ *
+ * @param startTime - イベントの開始時刻（ISO 8601形式）
+ * @param endTime - イベントの終了時刻（ISO 8601形式）
+ * @param dayStart - 1日の開始時刻（ISO 8601形式）
+ * @param dayEnd - 1日の終了時刻（ISO 8601形式）
+ * @returns イベントの位置情報（top: 上端位置%, height: 高さ%）
+ *
+ * @example
+ * ```typescript
+ * // 1日を0:00-24:00として、9:00-10:00のイベント
+ * calculateEventPosition(
+ *   "2026-01-27T09:00:00+09:00",
+ *   "2026-01-27T10:00:00+09:00",
+ *   "2026-01-27T00:00:00+09:00",
+ *   "2026-01-28T00:00:00+09:00"
+ * );
+ * // { top: 37.5, height: 4.166... }
+ * // (9時間 / 24時間 = 37.5%, 1時間 / 24時間 ≈ 4.17%)
+ * ```
+ */
+export function calculateEventPosition(
+	startTime: string,
+	endTime: string,
+	dayStart: string,
+	dayEnd: string,
+): EventPosition {
+	const eventStartMs = new Date(startTime).getTime();
+	const eventEndMs = new Date(endTime).getTime();
+	const dayStartMs = new Date(dayStart).getTime();
+	const dayEndMs = new Date(dayEnd).getTime();
+
+	const dayDuration = dayEndMs - dayStartMs;
+
+	if (dayDuration <= 0) {
+		return { top: 0, height: 0 };
+	}
+
+	// イベントを1日の範囲内にクリップ
+	const clippedStart = Math.max(eventStartMs, dayStartMs);
+	const clippedEnd = Math.min(eventEndMs, dayEndMs);
+
+	// イベントが完全に範囲外の場合
+	if (clippedStart >= clippedEnd) {
+		return { top: 0, height: 0 };
+	}
+
+	const top = ((clippedStart - dayStartMs) / dayDuration) * 100;
+	const height = ((clippedEnd - clippedStart) / dayDuration) * 100;
+
+	return { top, height };
+}
+
+// ============================================================
+// prepareTimelineEvents - タイムライン表示用のイベント変換
+// ============================================================
+
+/**
+ * タイムライン表示の準備結果
+ */
+export interface PreparedTimeline {
+	/** 終日イベントの配列 */
+	allDayEvents: TimelineEvent[];
+	/** 時間指定イベントの配列 */
+	timedEvents: TimelineEvent[];
+}
+
+/**
+ * イベント配列をタイムライン表示用に変換します
+ *
+ * 以下の処理を行います:
+ * 1. 終日イベントと時間指定イベントを分離
+ * 2. 時間指定イベントに列を割り当て
+ * 3. 各イベントにステータスを設定（"next"は最初の未来イベントのみ）
+ *
+ * @param events - 変換するイベントの配列
+ * @param now - 現在時刻
+ * @returns 終日イベントと時間指定イベントに分離されたタイムラインデータ
+ *
+ * @example
+ * ```typescript
+ * const events = [
+ *   { id: "1", title: "Meeting", isAllDay: false, startTime: "...", endTime: "...", ... },
+ *   { id: "2", title: "Holiday", isAllDay: true, startTime: "...", endTime: "...", ... },
+ * ];
+ * const result = prepareTimelineEvents(events, new Date());
+ * // { allDayEvents: [...], timedEvents: [...] }
+ * ```
+ */
+export function prepareTimelineEvents(
+	events: ReadonlyArray<InputEvent>,
+	now: Date,
+): PreparedTimeline {
+	// 終日イベントと時間指定イベントを分離
+	const allDayInputEvents: InputEvent[] = [];
+	const timedInputEvents: InputEvent[] = [];
+
+	for (const event of events) {
+		if (event.isAllDay) {
+			allDayInputEvents.push(event);
+		} else {
+			timedInputEvents.push(event);
+		}
+	}
+
+	// 時間指定イベントに列を割り当て
+	const columnAssignments = assignColumns(timedInputEvents);
+	const columnMap = new Map(columnAssignments.map((a) => [a.id, a.column]));
+
+	// 各イベントが重なっているグループごとにtotalColumnsを計算
+	// これにより、3つ重なっていれば33.3%、4つ重なっていれば25%ずつになる
+	const totalColumnsMap = calculateTotalColumnsPerEvent(
+		timedInputEvents,
+		columnAssignments,
+	);
+
+	// 開始時刻でソートして"next"イベントを特定
+	const sortedTimedEvents = [...timedInputEvents].sort(
+		(a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+	);
+
+	// 最初の未来イベントを見つける
+	let nextEventId: string | null = null;
+	for (const event of sortedTimedEvents) {
+		const status = getEventStatus(event, now);
+		if (status === "future") {
+			nextEventId = event.id;
+			break;
+		}
+	}
+
+	// TimelineEvent配列を構築
+	const timedEvents: TimelineEvent[] = timedInputEvents.map((event) => {
+		const baseStatus = getEventStatus(event, now);
+		const status: EventStatus = event.id === nextEventId ? "next" : baseStatus;
+
+		return {
+			...event,
+			column: columnMap.get(event.id) ?? 0,
+			totalColumns: totalColumnsMap.get(event.id) ?? 1,
+			status,
+		};
+	});
+
+	// 終日イベントも同様にステータスを設定
+	const allDayEvents: TimelineEvent[] = allDayInputEvents.map((event) => {
+		const baseStatus = getEventStatus(event, now);
+
+		return {
+			...event,
+			column: 0,
+			totalColumns: 1,
+			status: baseStatus,
+		};
+	});
+
+	return { allDayEvents, timedEvents };
+}
+
+// ============================================================
+// 補助関数
+// ============================================================
+
+/**
+ * 重複するイベントグループの合計列数を計算します
+ *
+ * 同じ時間帯に重複するイベントのグループごとに
+ * 必要な列数を計算します。
+ *
+ * @param events - イベントの配列
+ * @param columnAssignments - 列割り当て結果
+ * @returns イベントIDと合計列数のマップ
+ *
+ * @internal
+ */
+export function calculateTotalColumnsPerEvent(
+	events: ReadonlyArray<Pick<InputEvent, "id" | "startTime" | "endTime">>,
+	columnAssignments: ColumnAssignment[],
+): Map<string, number> {
+	const columnMap = new Map(columnAssignments.map((a) => [a.id, a.column]));
+	const result = new Map<string, number>();
+
+	// 各イベントについて、重複するイベント群の最大列数を計算
+	for (const event of events) {
+		const overlappingEvents = events.filter((other) =>
+			eventsOverlap(event, other),
+		);
+
+		const maxColumn = Math.max(
+			...overlappingEvents.map((e) => columnMap.get(e.id) ?? 0),
+		);
+
+		result.set(event.id, maxColumn + 1);
+	}
+
+	return result;
+}


### PR DESCRIPTION
## Summary
- 時間が被っているイベントを横に並べて表示（3つなら33.3%ずつ）
- 現在時刻を赤いラインでリアルタイム表示（60秒ごと更新）
- 現在/次のイベントを色分けで強調（NOW/NEXTバッジ）
- カレンダー情報（メールアドレス/カレンダー名）を表示

## 新規ファイル
| ファイル | 役割 |
|---------|------|
| `lib/utils/timeline.ts` | 重複検出・列割り当て・ステータス判定 |
| `hooks/useCurrentTime.ts` | 60秒ごとに更新される現在時刻フック |
| `components/calendar/CurrentTimeIndicator.tsx` | 現在時刻の赤いライン |
| `components/calendar/TimelineEvent.tsx` | タイムライン上の個別イベント |
| `components/calendar/TimelineView.tsx` | タイムラインのメインコンポーネント |

## 変更ファイル
- `components/calendar/TodayView.tsx`: EventList → TimelineView に置き換え

## スクリーンショット
- 時刻グリッド（06:00〜22:00）
- 重複イベントの横並び表示
- 現在時刻インジケーター（赤いライン）
- ステータス別色分け（past/current/next/future）

## Test plan
- [ ] 重複イベントが横に並ぶことを確認
- [ ] 現在時刻の赤いラインが表示されることを確認
- [ ] 現在進行中のイベントにNOWバッジが表示されることを確認
- [ ] 次のイベントにNEXTバッジが表示されることを確認
- [ ] カレンダー情報が表示されることを確認