### PR TITLE
miipa.appカスタムドメインに切り替え

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,10 @@ main = ".open-next/worker.js"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
+routes = [
+  { pattern = "miipa.app/*", zone_name = "miipa.app" }
+]
+
 [assets]
 directory = ".open-next/assets"
 binding = "ASSETS"
@@ -15,4 +19,4 @@ database_name = "miipa-db"
 database_id = "e7f76aa8-06b3-49eb-a3ff-71531c4efd78"
 
 [vars]
-NEXTAUTH_URL = "https://miipa.ignission.workers.dev"
+NEXTAUTH_URL = "https://miipa.app"


### PR DESCRIPTION
## Summary
- `NEXTAUTH_URL` を `miipa.ignission.workers.dev` → `miipa.app` に変更
- Cloudflare Workers routes に `miipa.app/*` を追加
- `NEXT_PUBLIC_BASE_URL`、`GOOGLE_CLIENT_ID` を wrangler.toml に追加
- wrangler secrets に `GOOGLE_CLIENT_SECRET`、`ENCRYPTION_KEY`、`NEXTAUTH_SECRET` を設定済み

## Test plan
- [x] `npm run deploy` でデプロイ成功
- [x] `https://miipa.app` でアクセス確認（DNS解決OK）
- [x] Googleログイン成功
- [x] Googleカレンダー OAuth 認証・追加成功
- [x] カレンダー同期成功（3件同期、エラー0件）