### PR TITLE
Renovateによる依存関係の自動アップデートを導入

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"timezone": "Asia/Tokyo",
+	"schedule": ["after 9pm on sunday"],
+	"labels": ["dependencies"],
+	"packageRules": [
+		{
+			"description": "Automerge minor/patch updates for stable packages (v1.0.0+) after 3 days",
+			"matchUpdateTypes": ["minor", "patch"],
+			"matchCurrentVersion": ">=1.0.0",
+			"automerge": true,
+			"minimumReleaseAge": "3 days"
+		},
+		{
+			"description": "Automerge devDependencies minor/patch updates",
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": true
+		},
+		{
+			"description": "Group React related packages",
+			"groupName": "React",
+			"matchPackageNames": [
+				"react",
+				"react-dom",
+				"@types/react",
+				"@types/react-dom"
+			]
+		},
+		{
+			"description": "Group Next.js related packages",
+			"groupName": "Next.js",
+			"matchPackageNames": ["next", "@opennextjs/cloudflare"]
+		},
+		{
+			"description": "Group Cloudflare related packages",
+			"groupName": "Cloudflare",
+			"matchPackageNames": ["wrangler", "@cloudflare/workers-types"]
+		},
+		{
+			"description": "Group UI framework packages (Panda CSS, Park UI, Ark UI)",
+			"groupName": "UI",
+			"matchPackageNames": [
+				"@pandacss/dev",
+				"@park-ui/panda-preset",
+				"@ark-ui/react"
+			]
+		},
+		{
+			"description": "next-auth is currently on beta (5.0.0-beta.30). Disable Renovate updates until stable release to avoid breaking changes.",
+			"matchPackageNames": ["next-auth"],
+			"enabled": false
+		}
+	],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["before 4am on monday"],
+		"automerge": true
+	}
+}


### PR DESCRIPTION
## Summary

- Renovate設定ファイル（renovate.json）を追加し、依存関係の自動アップデートを有効化
- 安定版パッケージのminor/patchは3日待機後にautomerge、majorは手動レビュー
- 関連パッケージのグルーピングでPR数を削減（React / Next.js / Cloudflare / UI）

## 設定内容

| 項目 | 設定 |
|------|------|
| スケジュール | 日曜21時以降（Asia/Tokyo） |
| Automerge | 安定版(v1+) minor/patch（3日待機後） |
| devDeps | minor/patch を automerge |
| lockFile保守 | 月曜4時前に実行、automerge |
| next-auth | beta安定化まで対象外 |
| ラベル | `dependencies` |

## マージ後の作業

[Mend Renovate GitHub App](https://github.com/apps/renovate) をリポジトリにインストールすることで有効化されます。