### PR TITLE
チャット送信キー設定機能の追加

### DIFF
--- a/app/api/settings/chat/route.ts
+++ b/app/api/settings/chat/route.ts
@@ -1,0 +1,156 @@
+/**
+ * チャット設定 API エンドポイント
+ *
+ * チャット送信キー設定の取得・更新を行います。
+ * Auth.js認証チェック後、D1コンテキストを使用して設定を操作します。
+ *
+ * @endpoint GET /api/settings/chat
+ * @endpoint PUT /api/settings/chat
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { isErr, isOk } from "@/lib/domain/shared/result";
+import { createAuthenticatedContext } from "@/lib/infrastructure/cloudflare/api-context";
+
+/** 送信キーの設定値 */
+type SendKey = "enter" | "cmd+enter";
+
+/** デフォルトの送信キー */
+const DEFAULT_SEND_KEY: SendKey = "enter";
+
+/** 許可される送信キーの値 */
+const VALID_SEND_KEYS: readonly SendKey[] = ["enter", "cmd+enter"];
+
+/**
+ * チャット設定更新リクエストボディ
+ */
+interface UpdateChatSettingsRequest {
+	/** 送信キー設定 */
+	readonly sendKey?: string;
+}
+
+/**
+ * 値が有効な送信キーかどうかを判定する
+ *
+ * @param value - 判定対象の値
+ * @returns 有効な送信キーの場合はtrue
+ */
+function isSendKey(value: string | null | undefined): value is SendKey {
+	return VALID_SEND_KEYS.includes(value as SendKey);
+}
+
+/**
+ * 現在のチャット送信キー設定を取得する
+ *
+ * - D1からchat_send_key設定を取得
+ * - 未設定の場合はデフォルト値（enter）を返す
+ *
+ * @returns 送信キー設定のレスポンス
+ */
+export async function GET() {
+	const ctxResult = await createAuthenticatedContext();
+	if (isErr(ctxResult)) {
+		return NextResponse.json(
+			{
+				error: {
+					code: ctxResult.error.code,
+					message: ctxResult.error.message,
+				},
+			},
+			{ status: ctxResult.error.status },
+		);
+	}
+	const { calendarCtx } = ctxResult.value;
+
+	const result =
+		await calendarCtx.configRepository.getSetting("chat_send_key");
+	if (isErr(result)) {
+		return NextResponse.json(
+			{
+				error: {
+					code: "CONFIG_ERROR",
+					message: "チャット送信キー設定の取得に失敗しました",
+				},
+			},
+			{ status: 500 },
+		);
+	}
+
+	const sendKey: SendKey = isSendKey(result.value)
+		? result.value
+		: DEFAULT_SEND_KEY;
+
+	return NextResponse.json({ sendKey });
+}
+
+/**
+ * チャット送信キー設定を更新する
+ *
+ * - sendKeyのバリデーション（"enter" または "cmd+enter" のみ許可）
+ * - D1にchat_send_key設定を保存
+ *
+ * @param request - リクエストオブジェクト
+ * @returns 更新結果
+ */
+export async function PUT(request: NextRequest) {
+	const ctxResult = await createAuthenticatedContext();
+	if (isErr(ctxResult)) {
+		return NextResponse.json(
+			{
+				error: {
+					code: ctxResult.error.code,
+					message: ctxResult.error.message,
+				},
+			},
+			{ status: ctxResult.error.status },
+		);
+	}
+	const { calendarCtx } = ctxResult.value;
+
+	let body: UpdateChatSettingsRequest;
+	try {
+		body = (await request.json()) as UpdateChatSettingsRequest;
+	} catch {
+		return NextResponse.json(
+			{
+				success: false,
+				error: {
+					code: "INVALID_REQUEST",
+					message: "リクエストボディのJSONパースに失敗しました",
+				},
+			},
+			{ status: 400 },
+		);
+	}
+
+	if (!body.sendKey || !isSendKey(body.sendKey)) {
+		return NextResponse.json(
+			{
+				success: false,
+				error: {
+					code: "INVALID_REQUEST",
+					message:
+						"sendKeyには \"enter\" または \"cmd+enter\" を指定してください",
+				},
+			},
+			{ status: 400 },
+		);
+	}
+
+	const result = await calendarCtx.configRepository.setSetting(
+		"chat_send_key",
+		body.sendKey,
+	);
+
+	if (isOk(result)) {
+		return NextResponse.json({ success: true });
+	}
+
+	return NextResponse.json(
+		{
+			success: false,
+			error: { code: result.error.code, message: result.error.message },
+		},
+		{ status: 500 },
+	);
+}

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -11,6 +11,7 @@
 
 import { type KeyboardEvent, useCallback, useEffect, useRef } from "react";
 import { css } from "@/styled-system/css";
+import type { SendKeyType } from "@/hooks/useSendKeySetting";
 
 // ============================================================
 // 型定義
@@ -28,6 +29,10 @@ interface ChatInputProps {
 	onSend: () => void;
 	/** ローディング状態 */
 	isLoading: boolean;
+	/** 送信キー設定 */
+	sendKey: SendKeyType;
+	/** 送信キー切替ハンドラ */
+	onToggleSendKey: () => void;
 }
 
 // ============================================================
@@ -89,6 +94,8 @@ export function ChatInput({
 	onChange,
 	onSend,
 	isLoading,
+	sendKey,
+	onToggleSendKey,
 }: ChatInputProps) {
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -119,18 +126,30 @@ export function ChatInput({
 	/**
 	 * キーボードイベントハンドラ
 	 *
-	 * Enter: 送信、Shift+Enter: 改行
+	 * sendKey === "enter": Enter送信 / Shift+Enter改行
+	 * sendKey === "cmd-enter": Cmd+Enter(Mac) or Ctrl+Enter(Win)送信 / Enter改行
 	 */
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent<HTMLTextAreaElement>) => {
-			if (e.key === "Enter" && !e.shiftKey) {
-				e.preventDefault();
-				if (!isLoading && value.trim()) {
-					onSend();
+			if (sendKey === "enter") {
+				// Enterモード: Enter送信 / Shift+Enter改行
+				if (e.key === "Enter" && !e.shiftKey) {
+					e.preventDefault();
+					if (!isLoading && value.trim()) {
+						onSend();
+					}
+				}
+			} else {
+				// Cmd+Enterモード: Cmd+Enter(Mac) or Ctrl+Enter(Win)送信 / Enter改行
+				if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+					e.preventDefault();
+					if (!isLoading && value.trim()) {
+						onSend();
+					}
 				}
 			}
 		},
-		[isLoading, value, onSend],
+		[sendKey, isLoading, value, onSend],
 	);
 
 	const canSend = !isLoading && value.trim().length > 0;
@@ -187,6 +206,47 @@ export function ChatInput({
 					},
 				})}
 			/>
+
+			{/* 送信キー切替ボタン */}
+			<button
+				type="button"
+				onClick={onToggleSendKey}
+				title={
+					sendKey === "enter"
+						? "Enter で送信 / Shift+Enter で改行"
+						: "⌘+Enter で送信 / Enter で改行"
+				}
+				aria-label={`送信キー: ${sendKey === "enter" ? "Enter" : "⌘+Enter"}`}
+				className={css({
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					height: "11",
+					px: "2",
+					flexShrink: 0,
+					borderRadius: "lg",
+					bg: "transparent",
+					color: "fg.muted",
+					border: "1px solid",
+					borderColor: "border.default",
+					cursor: "pointer",
+					fontSize: "xs",
+					fontFamily: "mono",
+					whiteSpace: "nowrap",
+					transition: "all 0.2s ease",
+					_hover: {
+						color: "fg.default",
+						bg: "bg.subtle",
+					},
+					_focusVisible: {
+						outline: "3px solid",
+						outlineColor: "neutral.9",
+						outlineOffset: "2px",
+					},
+				})}
+			>
+				{sendKey === "enter" ? "↵" : "⌘↵"}
+			</button>
 
 			{/* 送信ボタン */}
 			<button

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -11,6 +11,7 @@
 
 import { useCallback, useState } from "react";
 import { useChat } from "@/hooks/useChat";
+import { useSendKeySetting } from "@/hooks/useSendKeySetting";
 import { css } from "@/styled-system/css";
 import { ChatInput } from "./ChatInput";
 import { ChatMessage } from "./ChatMessage";
@@ -139,6 +140,7 @@ export function ChatPanel() {
 		error,
 		messagesEndRef,
 	} = useChat();
+	const { sendKey, toggleSendKey } = useSendKeySetting();
 
 	const [isExpanded, setIsExpanded] = useState(false);
 
@@ -309,6 +311,8 @@ export function ChatPanel() {
 				onChange={setInput}
 				onSend={handleSend}
 				isLoading={isLoading}
+				sendKey={sendKey}
+				onToggleSendKey={toggleSendKey}
 			/>
 		</section>
 	);

--- a/hooks/useSendKeySetting.ts
+++ b/hooks/useSendKeySetting.ts
@@ -1,0 +1,146 @@
+"use client";
+
+/**
+ * 送信キー設定フック
+ *
+ * チャットのメッセージ送信キー（Enter / Cmd+Enter）を
+ * 管理するためのカスタムフックです。
+ * 楽観的更新により即座にUIへ反映し、API保存に失敗した場合はロールバックします。
+ *
+ * @module hooks/useSendKeySetting
+ *
+ * @example
+ * ```tsx
+ * const { sendKey, toggleSendKey, isLoading } = useSendKeySetting();
+ * ```
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/** 送信キーの設定値 */
+export type SendKeyType = "enter" | "cmd+enter";
+
+/** 送信キー設定APIレスポンスの型 */
+interface SendKeySettingResponse {
+	/** 送信キー設定 */
+	sendKey: SendKeyType;
+}
+
+/**
+ * useSendKeySettingフックの戻り値型
+ */
+export interface UseSendKeySettingReturn {
+	/** 現在の送信キー設定 */
+	sendKey: SendKeyType;
+	/** 送信キーをトグルする関数（楽観的更新付き） */
+	toggleSendKey: () => void;
+	/** ローディング状態（初回取得中） */
+	isLoading: boolean;
+}
+
+// ============================================================
+// 定数
+// ============================================================
+
+/** 送信キー設定のデフォルト値 */
+const DEFAULT_SEND_KEY: SendKeyType = "enter";
+
+/** 送信キー設定APIのエンドポイント */
+const API_ENDPOINT = "/api/settings/chat";
+
+// ============================================================
+// ヘルパー関数
+// ============================================================
+
+/**
+ * 送信キーの値をトグルする
+ *
+ * @param current - 現在の送信キー設定
+ * @returns トグル後の送信キー設定
+ */
+function toggleValue(current: SendKeyType): SendKeyType {
+	return current === "enter" ? "cmd+enter" : "enter";
+}
+
+// ============================================================
+// メインフック
+// ============================================================
+
+/**
+ * 送信キー設定フック
+ *
+ * チャットのメッセージ送信キー設定を管理します。
+ * 初回マウント時にAPIから設定を取得し、トグル操作では楽観的更新を行います。
+ *
+ * @returns 送信キー設定の状態と操作関数
+ */
+export function useSendKeySetting(): UseSendKeySettingReturn {
+	const [sendKey, setSendKey] = useState<SendKeyType>(DEFAULT_SEND_KEY);
+	const [isLoading, setIsLoading] = useState(true);
+
+	/**
+	 * 初回マウント時にAPIから送信キー設定を取得する
+	 */
+	useEffect(() => {
+		async function loadSetting() {
+			try {
+				const response = await fetch(API_ENDPOINT);
+				if (response.ok) {
+					const data: SendKeySettingResponse = await response.json();
+					if (data.sendKey) {
+						setSendKey(data.sendKey);
+					}
+				}
+			} catch {
+				// 取得失敗時はデフォルト値を維持
+			} finally {
+				setIsLoading(false);
+			}
+		}
+
+		loadSetting();
+	}, []);
+
+	/**
+	 * 送信キー設定をトグルする（楽観的更新）
+	 *
+	 * 1. 現在値を保存
+	 * 2. 即座にUIに反映（stateを更新）
+	 * 3. PUT APIを呼び出し
+	 * 4. 失敗したら元の値にロールバック
+	 */
+	const toggleSendKey = useCallback(() => {
+		const previousValue = sendKey;
+		const nextValue = toggleValue(previousValue);
+
+		// 楽観的更新: 即座にUIへ反映
+		setSendKey(nextValue);
+
+		// APIへ保存（失敗時はロールバック）
+		fetch(API_ENDPOINT, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ sendKey: nextValue }),
+		})
+			.then((response) => {
+				if (!response.ok) {
+					// 保存失敗: ロールバック
+					setSendKey(previousValue);
+				}
+			})
+			.catch(() => {
+				// ネットワークエラー: ロールバック
+				setSendKey(previousValue);
+			});
+	}, [sendKey]);
+
+	return {
+		sendKey,
+		toggleSendKey,
+		isLoading,
+	};
+}


### PR DESCRIPTION
## Summary

- チャット入力でEnter送信 / Cmd+Enter送信を切替可能にした
- 送信ボタン左にトグルボタン（`↵` / `⌘↵`）を追加
- 設定はD1に永続化され、リロード後も保持される

## 変更内容

| ファイル | 操作 | 内容 |
|---------|------|------|
| `app/api/settings/chat/route.ts` | 新規 | GET/PUT エンドポイント |
| `hooks/useSendKeySetting.ts` | 新規 | 送信キー設定管理フック（楽観的更新） |
| `components/chat/ChatInput.tsx` | 変更 | handleKeyDown分岐、トグルボタン追加 |
| `components/chat/ChatPanel.tsx` | 変更 | フック呼び出し、props渡し |

## 動作仕様

- **Enterモード（デフォルト）**: Enter→送信 / Shift+Enter→改行
- **Cmd+Enterモード**: Cmd+Enter(Mac) or Ctrl+Enter(Win)→送信 / Enter→改行
- トグルボタンクリックで即座に切替（楽観的更新、失敗時ロールバック）

## テスト方法

1. チャット入力欄に送信キー切替ボタンが表示されることを確認
2. デフォルト（Enter送信）でEnter→送信、Shift+Enter→改行を確認
3. ボタンクリックでCmd+Enterモードに切替→Cmd+Enter→送信、Enter→改行を確認
4. ページリロード後も設定が保持されることを確認
5. `npx biome check .` がパスすることを確認

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable chat send-key settings allowing users to toggle between sending messages with Enter (using Shift+Enter for newlines) or Cmd+Enter (using Enter for newlines).
  * Added a toggle button in the chat input clearly displaying the current send-key mode for easy switching.
  * Chat preferences are now persisted and automatically synchronized across sessions with optimistic UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->