### PR TITLE
サジェスチョンボタン押下時にメッセージを即送信するよう修正

### DIFF
--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -145,14 +145,14 @@ export function ChatPanel() {
 	/**
 	 * 質問候補選択時のハンドラ
 	 *
-	 * 候補テキストを入力に設定してパネルを展開状態にする
+	 * パネルを展開状態にしてメッセージを送信する
 	 */
 	const handleSuggestionSelect = useCallback(
 		(suggestion: string) => {
-			setInput(suggestion);
 			setIsExpanded(true);
+			sendMessage(suggestion);
 		},
-		[setInput],
+		[sendMessage],
 	);
 
 	/**

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -66,7 +66,7 @@ export interface UseChatReturn {
 	/** 入力テキストの更新関数 */
 	setInput: (input: string) => void;
 	/** メッセージ送信関数 */
-	sendMessage: () => Promise<void>;
+	sendMessage: (overrideInput?: string) => Promise<void>;
 	/** ローディング状態 */
 	isLoading: boolean;
 	/** エラー情報 */
@@ -171,8 +171,8 @@ export function useChat(): UseChatReturn {
 	/**
 	 * メッセージを送信し、SSEストリームからレスポンスを受信する
 	 */
-	const sendMessage = useCallback(async () => {
-		const trimmedInput = input.trim();
+	const sendMessage = useCallback(async (overrideInput?: string) => {
+		const trimmedInput = (overrideInput ?? input).trim();
 		if (!trimmedInput || isLoading) {
 			return;
 		}


### PR DESCRIPTION
## Summary

- サジェスチョンボタン（「今日の予定は？」等）押下時に、テキスト入力欄にセットするだけでなく即座にメッセージを送信するよう修正
- `sendMessage` に `overrideInput` 引数を追加し、Reactのバッチ更新によるstate反映遅延を回避
- 通常のテキスト入力→送信ボタンの動作には影響なし

## 変更内容

| ファイル | 変更 |
|---------|------|
| `hooks/useChat.ts` | `sendMessage(overrideInput?: string)` に引数追加、型定義更新 |
| `components/chat/ChatPanel.tsx` | `handleSuggestionSelect` で `sendMessage(suggestion)` を呼び出し |

## Test plan

- [ ] サジェスチョンボタンを押すと即座にメッセージが送信されることを確認
- [ ] 通常のテキスト入力→送信ボタンの動作が壊れていないことを確認
- [ ] パネル展開時に送信が正しく動作することを確認
- [ ] `npx biome check .` でエラーがないことを確認
- [ ] `npm run build` でビルドが通ることを確認

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Chat suggestions now send immediately when selected, rather than populating the input field for manual submission.
  * The chat panel automatically expands when a suggestion is activated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->