### PR TITLE
Fix: redirect authenticated users to /home

### DIFF
--- a/mobile/app/(auth)/_layout.tsx
+++ b/mobile/app/(auth)/_layout.tsx
@@ -46,7 +46,7 @@ export default function AuthLayout() {
 			}}
 		>
 			<Tabs.Screen
-				name="index"
+				name="home"
 				options={{
 					title: "今日",
 					tabBarIcon: ({ color, focused }) => (

--- a/mobile/app/(auth)/home.tsx
+++ b/mobile/app/(auth)/home.tsx
@@ -5,7 +5,7 @@
  * Web用のレイアウト調整（max-width, padding等）を含みます。
  * 未認証WebアクセスではLPコンポーネントを条件表示します。
  *
- * @module app/(auth)/index
+ * @module app/(auth)/home
  */
 
 import { useCallback, useEffect, useState } from "react";

--- a/mobile/app/(auth)/setup.tsx
+++ b/mobile/app/(auth)/setup.tsx
@@ -57,7 +57,7 @@ export default function SetupScreen() {
 	 * セットアップ完了時：メイン画面へ遷移
 	 */
 	const handleStart = useCallback(() => {
-		router.replace("/(auth)");
+		router.replace("/(auth)/home");
 	}, []);
 
 	/**

--- a/mobile/app/auth-callback.tsx
+++ b/mobile/app/auth-callback.tsx
@@ -96,7 +96,7 @@ export default function AuthCallbackScreen() {
 
 					await Promise.all(savePromises);
 
-					router.replace("/(auth)");
+					router.replace("/(auth)/home");
 				} catch (e) {
 					console.error("[auth-callback] コード交換エラー:", e);
 					const message =

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -15,7 +15,7 @@ export default function IndexScreen() {
 	}
 
 	if (isAuthenticated) {
-		return <Redirect href="/(auth)" />;
+		return <Redirect href="/(auth)/home" />;
 	}
 
 	return (

--- a/mobile/app/sign-in.tsx
+++ b/mobile/app/sign-in.tsx
@@ -25,7 +25,7 @@ export default function SignInScreen() {
 
 	// 認証済みならタブ画面にリダイレクト
 	if (isAuthenticated) {
-		return <Redirect href="/(auth)" />;
+		return <Redirect href="/(auth)/home" />;
 	}
 
 	return (


### PR DESCRIPTION
## Summary
- ログイン後のホーム画面を `/` から `/home` に移動
- `(auth)/index.tsx` を `(auth)/home.tsx` にリネームし、Expo Routerのグループルーティングで `/home` にマッピングされるように変更
- 全リダイレクト先（index, sign-in, auth-callback, setup）を `/(auth)/home` に更新

## Background
ランディングページ（サービス説明）を `/` に配置したが、ログイン後も `/(auth)/index.tsx` が `/` にマッピングされるため、カレンダー一覧がルートに表示されていた。

## Test plan
- [ ] 未認証で `/` にアクセス → ランディングページが表示される
- [ ] ログイン後 `/home` にリダイレクトされる
- [ ] `/home` でカレンダー一覧（今日の予定）が表示される
- [ ] タブナビゲーション（今日/今週/AI/設定）が正常に動作する
- [ ] セットアップ完了後 `/home` に遷移する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal navigation routing structure to improve consistency across authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->