### PR TITLE
Fix iOS build: upgrade gesture-handler for RN 0.81 compat

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -30,6 +30,10 @@
 		}
 	},
 	"submit": {
-		"production": {}
+		"production": {
+			"ios": {
+				"ascAppId": "6759304369"
+			}
+		}
 	}
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -34,7 +34,7 @@
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
 		"react-native": "0.81.5",
-		"react-native-gesture-handler": "~2.27.0",
+		"react-native-gesture-handler": "~2.28.0",
 		"react-native-reanimated": "~4.1.1",
 		"react-native-safe-area-context": "~5.6.0",
 		"react-native-screens": "~4.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
 				"react": "19.2.4",
 				"react-dom": "19.2.4",
 				"react-native": "0.81.5",
-				"react-native-gesture-handler": "~2.27.0",
+				"react-native-gesture-handler": "~2.28.0",
 				"react-native-reanimated": "~4.1.1",
 				"react-native-safe-area-context": "~5.6.0",
 				"react-native-screens": "~4.16.0",
@@ -11281,9 +11281,9 @@
 			}
 		},
 		"node_modules/react-native-gesture-handler": {
-			"version": "2.27.2",
-			"resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.27.2.tgz",
-			"integrity": "sha512-+kNaY2m7uQu5+5ls8os6z92DTk9expsEAYsaPv30n08mrqX2r64G8iVGDwNWzZcId54+P7RlDnhyszTql0sQ0w==",
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+			"integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
 			"license": "MIT",
 			"dependencies": {
 				"@egjs/hammerjs": "^2.0.17",


### PR DESCRIPTION
## Summary
- `react-native-gesture-handler` を ~2.27.0 から ~2.28.0 にアップグレード
  - RN 0.81.5 で `shadowNodeFromValue` の未定義エラーが発生していた問題を修正
- `eas.json` の submit 設定に `ascAppId` を追加（TestFlight提出用）

## Test plan
- [x] EAS local build (`eas build --platform ios --profile production --local`) 成功
- [x] TestFlight 提出完了（buildNumber: 23）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added iOS App Store Connect identifier to production submission configuration for seamless app store deployment
  * Updated mobile gesture handling library to latest compatible version for improved touch interaction responsiveness and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->