### PR TITLE
Fix post-login redirect to /home

### DIFF
--- a/mobile/app/auth-callback.tsx
+++ b/mobile/app/auth-callback.tsx
@@ -10,16 +10,10 @@
  */
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useState } from "react";
-import {
-	ActivityIndicator,
-	Platform,
-	StyleSheet,
-	Text,
-	View,
-} from "react-native";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import type { StoredUser } from "../src/auth";
+import { useAuth } from "../src/auth";
 import { AUTH_CONFIG } from "../src/auth/config";
-import type { StoredUser } from "../src/auth/storage";
-import { saveRefreshToken, saveToken, saveUser } from "../src/auth/storage";
 
 /** エラー表示後にサインイン画面へ戻るまでの遅延(ms) */
 const REDIRECT_DELAY_MS = 3000;
@@ -38,6 +32,7 @@ function showErrorAndRedirect(
 }
 
 export default function AuthCallbackScreen() {
+	const { login } = useAuth();
 	const [error, setError] = useState<string | null>(null);
 
 	const params = useLocalSearchParams<{
@@ -82,19 +77,8 @@ export default function AuthCallbackScreen() {
 						user: StoredUser;
 					};
 
-					// トークンとユーザー情報を並列保存
-					const savePromises: Promise<void>[] = [
-						saveToken(data.token),
-						saveUser(data.user),
-					];
-
-					// Mobile のみ: リフレッシュトークンを SecureStore に保存
-					// Web は httpOnly Cookie で管理されるため保存不要
-					if (Platform.OS !== "web") {
-						savePromises.push(saveRefreshToken(data.refreshToken));
-					}
-
-					await Promise.all(savePromises);
+					// トークンとユーザー情報を保存し、AuthContext のステートも更新
+					await login(data.token, data.user, data.refreshToken);
 
 					router.replace("/(auth)/home");
 				} catch (e) {
@@ -109,7 +93,7 @@ export default function AuthCallbackScreen() {
 			// パラメータが不足している場合
 			showErrorAndRedirect(setError, "認証パラメータが不足しています");
 		})();
-	}, [params.code, params.error, params.message]);
+	}, [params.code, params.error, params.message, login]);
 
 	return (
 		<View style={styles.container}>

--- a/mobile/src/auth/context.tsx
+++ b/mobile/src/auth/context.tsx
@@ -80,6 +80,12 @@ interface AuthState {
 	signIn: () => Promise<void>;
 	/** ログアウト実行 */
 	signOut: () => Promise<void>;
+	/** 認証情報を保存してステートを更新（auth-callback用） */
+	login: (
+		token: string,
+		user: StoredUser,
+		refreshToken?: string,
+	) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthState | null>(null);
@@ -411,6 +417,32 @@ export function AuthProvider({ children }: AuthProviderProps) {
 	}, [promptAsync]);
 
 	/**
+	 * 認証情報をストレージに保存し、React ステートも同時に更新する
+	 *
+	 * auth-callback 画面など、AuthProvider 外部で取得したトークンを
+	 * コンテキストに反映させるために使用する。
+	 */
+	const login = useCallback(
+		async (newToken: string, newUser: StoredUser, refreshToken?: string) => {
+			// ストレージに保存
+			const savePromises: Promise<void>[] = [
+				saveToken(newToken),
+				saveUser(newUser),
+			];
+			// Mobile のみ: リフレッシュトークンを SecureStore に保存
+			if (Platform.OS !== "web" && refreshToken) {
+				savePromises.push(saveRefreshToken(refreshToken));
+			}
+			await Promise.all(savePromises);
+
+			// React ステートを更新
+			setToken(newToken);
+			setUser(newUser);
+		},
+		[],
+	);
+
+	/**
 	 * ログアウト実行
 	 *
 	 * Web: Hono API のログアウトエンドポイントを呼び出し（Cookie削除）
@@ -442,8 +474,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
 			token,
 			signIn,
 			signOut,
+			login,
 		}),
-		[isLoading, isSigningIn, user, token, signIn, signOut],
+		[isLoading, isSigningIn, user, token, signIn, signOut, login],
 	);
 
 	return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
## Summary

- ログイン後に `/home` に遷移せずランディングページに戻される問題を修正
- `auth-callback` がストレージにトークンを保存するだけで `AuthContext` の React ステートを更新していなかったため、`(auth)/_layout` の `isAuthenticated` が `false` のままリダイレクトされていた
- `AuthContext` に `login` メソッドを追加し、ストレージ保存とステート更新を一括で行うようにした

## Test plan

- [ ] Web: Google OAuth ログイン後に `/home` へ正常に遷移すること
- [ ] Web: ログアウト → 再ログインで `/home` に遷移すること
- [ ] Mobile: expo-auth-session によるログインが引き続き動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated authentication login flow by replacing scattered manual token and credential persistence operations with a unified, centralized login method. This streamlines code consistency, reduces redundant logic, and improves state management across the authentication system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->