### PR TITLE
Fix: モバイルチャット画面でキーボードが閉じない問題を修正

### DIFF
--- a/mobile/src/components/chat/chat-panel.tsx
+++ b/mobile/src/components/chat/chat-panel.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useCallback, useState } from "react";
-import { Platform, Pressable, Text, View } from "react-native";
+import { Keyboard, KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from "react-native";
 import Svg, { Path } from "react-native-svg";
 import { ChatInput, type SendKeyType } from "./chat-input";
 import { ChatMessage } from "./chat-message";
@@ -146,6 +146,7 @@ export function ChatPanel({
 		if (!isExpanded) {
 			setIsExpanded(true);
 		}
+		Keyboard.dismiss();
 		sendMessage();
 	}, [isExpanded, sendMessage]);
 
@@ -247,7 +248,7 @@ export function ChatPanel({
 
 	// Mobile: フルスクリーン表示
 	return (
-		<View className="flex-1 bg-bg">
+		<KeyboardAvoidingView behavior="padding" className="flex-1 bg-bg">
 			{/* ヘッダー */}
 			<View className="border-b border-border bg-bg px-4 py-3">
 				<Text className="text-center text-sm font-medium text-fg-muted">
@@ -256,7 +257,12 @@ export function ChatPanel({
 			</View>
 
 			{/* メッセージエリア */}
-			<View className="flex-1 gap-3 py-4">
+			<ScrollView
+				className="flex-1"
+				contentContainerClassName="gap-3 py-4"
+				keyboardDismissMode="on-drag"
+				keyboardShouldPersistTaps="handled"
+			>
 				{/* 会話が空の時: 質問候補を表示 */}
 				{!hasMessages && !isLoading && (
 					<ChatSuggestions onSelect={handleSuggestionSelect} />
@@ -283,7 +289,7 @@ export function ChatPanel({
 						<Text className="text-sm text-red-700">{error}</Text>
 					</View>
 				)}
-			</View>
+			</ScrollView>
 
 			{/* 入力エリア */}
 			<ChatInput
@@ -292,6 +298,6 @@ export function ChatPanel({
 				onSend={handleSend}
 				isLoading={isLoading}
 			/>
-		</View>
+		</KeyboardAvoidingView>
 	);
 }


### PR DESCRIPTION
## 概要

モバイルのAIチャット画面で、テキスト入力後にキーボードが閉じられない問題を修正。

## 変更内容

- `KeyboardAvoidingView` でラップし、キーボード表示時に入力エリアが隠れないように対応
- メッセージエリアを `ScrollView` に変更し、`keyboardDismissMode="on-drag"` を設定（スクロールでキーボードが閉じる）
- 送信時に `Keyboard.dismiss()` でキーボードを自動的に閉じる

## 影響範囲

- モバイル版のみ（Web版は変更なし）
- `mobile/src/components/chat/chat-panel.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Mobile chat experience enhanced with automatic keyboard dismissal when sending messages.
  * Improved message scrolling and navigation on mobile devices.
  * Better keyboard interaction handling during chat on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->