### PR TITLE
Fix week view timezone bug causing events to display on wrong day

### DIFF
--- a/mobile/app/(auth)/week.tsx
+++ b/mobile/app/(auth)/week.tsx
@@ -10,26 +10,24 @@ import {
 import { EventCard } from "../../src/components/calendar/EventCard";
 import type { UICalendarEvent } from "../../src/hooks/useEvents";
 import { useEvents } from "../../src/hooks/useEvents";
+import { formatDateKey } from "../../src/lib/calendar-utils";
 
 const DAYS_TO_SHOW = 7;
 
-/**
- * 日付キー（YYYY-MM-DD）を生成
- */
-function formatDateKey(date: Date): string {
-	const y = date.getFullYear();
-	const m = (date.getMonth() + 1).toString().padStart(2, "0");
-	const d = date.getDate().toString().padStart(2, "0");
-	return `${y}-${m}-${d}`;
-}
+/** JSTオフセット（ミリ秒）: UTC+9 */
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 /**
- * 日付ヘッダーのフォーマット
+ * 日付ヘッダーのフォーマット（JST基準）
  */
 function formatSectionHeader(date: Date, isToday: boolean): string {
-	const weekday = date.toLocaleDateString("ja-JP", { weekday: "short" });
-	const month = date.getMonth() + 1;
-	const day = date.getDate();
+	const jst = new Date(date.getTime() + JST_OFFSET_MS);
+	const weekday = jst.toLocaleDateString("ja-JP", {
+		weekday: "short",
+		timeZone: "UTC",
+	});
+	const month = jst.getUTCMonth() + 1;
+	const day = jst.getUTCDate();
 	return isToday
 		? `今日 ${month}/${day}（${weekday}）`
 		: `${month}/${day}（${weekday}）`;
@@ -60,10 +58,10 @@ export default function WeekScreen() {
 		await refresh();
 	}, [refresh]);
 
-	// イベントを日付ごとにセクション化
+	// イベントを日付ごとにセクション化（JST基準）
 	const sections: Section[] = useMemo(() => {
-		const today = new Date();
-		const todayKey = formatDateKey(today);
+		const now = new Date();
+		const todayKey = formatDateKey(now);
 
 		// イベントを日付でグルーピング
 		const grouped = new Map<string, UICalendarEvent[]>();
@@ -74,10 +72,10 @@ export default function WeekScreen() {
 			grouped.set(key, list);
 		}
 
-		// 7日分のセクションを生成
+		// 7日分のセクションを生成（1日=86400000ms ずつ進める）
+		const DAY_MS = 24 * 60 * 60 * 1000;
 		return Array.from({ length: DAYS_TO_SHOW }, (_, i) => {
-			const date = new Date(today);
-			date.setDate(today.getDate() + i);
+			const date = new Date(now.getTime() + i * DAY_MS);
 			const key = formatDateKey(date);
 			const dayEvents = grouped.get(key) ?? [];
 			const isToday = key === todayKey;


### PR DESCRIPTION
## Summary
- 週表示の`formatDateKey`がローカルタイムゾーン基準で日付キーを生成していたため、サーバー（JST基準）から返されるUTC時刻のイベントが誤った日付にグルーピングされていた
- `calendar-utils.ts`の共通`formatDateKey`（JST基準）を使用するように修正
- `formatSectionHeader`と日付イテレーションもJST基準に統一

## 原因
`week.tsx`が独自の`formatDateKey`を持ち、`date.getFullYear()`/`date.getDate()`（ローカルTZ依存）で日付キーを生成していた。一方、月表示（MonthView）は`calendar-utils.ts`のJST基準版を使っており正常動作していた。

## Test plan
- [ ] モバイルで週表示を開き、今日の予定が正しい日付に表示されることを確認
- [ ] 日付境界付近（0時前後）のイベントが正しい日にグルーピングされることを確認
- [ ] 月表示と週表示でイベントの日付が一致することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timezone handling in the week view to ensure dates and times display accurately.
  * Improved date header formatting with proper time zone adjustments.

* **Refactor**
  * Streamlined date calculation logic with external utility functions and optimized interval handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->