### PR TITLE
Fix sync button not refreshing events

### DIFF
--- a/mobile/src/api/events.ts
+++ b/mobile/src/api/events.ts
@@ -3,26 +3,42 @@ import { apiFetch } from "./client";
 
 /**
  * 今日のイベントを取得
+ *
+ * @param force - true の場合、バックエンドキャッシュをバイパスして再取得
  */
-export function fetchTodayEvents(): Promise<EventsApiResponse | null> {
-	return apiFetch<EventsApiResponse>("/events?range=today");
+export function fetchTodayEvents(
+	force = false,
+): Promise<EventsApiResponse | null> {
+	const params = force ? "?range=today&force=true" : "?range=today";
+	return apiFetch<EventsApiResponse>(`/events${params}`);
 }
 
 /**
  * 今週のイベントを取得
+ *
+ * @param force - true の場合、バックエンドキャッシュをバイパスして再取得
  */
-export function fetchWeekEvents(): Promise<EventsApiResponse | null> {
-	return apiFetch<EventsApiResponse>("/events?range=week");
+export function fetchWeekEvents(
+	force = false,
+): Promise<EventsApiResponse | null> {
+	const params = force ? "?range=week&force=true" : "?range=week";
+	return apiFetch<EventsApiResponse>(`/events${params}`);
 }
 
 /**
  * 指定月のイベントを取得
+ *
+ * @param year - 年
+ * @param month - 月（1〜12）
+ * @param force - true の場合、バックエンドキャッシュをバイパスして再取得
  */
 export function fetchMonthEvents(
 	year: number,
 	month: number,
+	force = false,
 ): Promise<EventsApiResponse | null> {
+	const forceParam = force ? "&force=true" : "";
 	return apiFetch<EventsApiResponse>(
-		`/events?range=month&year=${year}&month=${month}`,
+		`/events?range=month&year=${year}&month=${month}${forceParam}`,
 	);
 }

--- a/mobile/src/hooks/useCalendars.ts
+++ b/mobile/src/hooks/useCalendars.ts
@@ -8,6 +8,8 @@ import {
 	syncCalendars,
 	toggleCalendar,
 } from "../api/calendars";
+import { fetchTodayEvents, fetchWeekEvents } from "../api/events";
+import { toUIEvent } from "./useEvents";
 
 /**
  * カレンダー一覧取得フック
@@ -98,10 +100,32 @@ export function useSyncCalendars() {
 
 	return useMutation({
 		mutationFn: syncCalendars,
-		onSuccess: () => {
-			// 同期後にイベントとカレンダーを再取得
-			queryClient.invalidateQueries({ queryKey: ["events"] });
-			queryClient.invalidateQueries({ queryKey: ["calendars"] });
+		onSuccess: async () => {
+			// 同期後にカレンダー一覧を再取得
+			await queryClient.invalidateQueries({ queryKey: ["calendars"] });
+			// 同期後は強制リフレッシュでイベントを再取得（バックエンドキャッシュをバイパス）
+			await queryClient.fetchQuery({
+				queryKey: ["events", "today"],
+				queryFn: async () => {
+					const data = await fetchTodayEvents(true);
+					if (!data) return { events: [], lastSync: null };
+					return {
+						events: data.events.map(toUIEvent),
+						lastSync: data.lastSync ? new Date(data.lastSync) : null,
+					};
+				},
+			});
+			await queryClient.fetchQuery({
+				queryKey: ["events", "week"],
+				queryFn: async () => {
+					const data = await fetchWeekEvents(true);
+					if (!data) return { events: [], lastSync: null };
+					return {
+						events: data.events.map(toUIEvent),
+						lastSync: data.lastSync ? new Date(data.lastSync) : null,
+					};
+				},
+			});
 		},
 	});
 }

--- a/packages/api/src/lib/application/calendar/get-events.ts
+++ b/packages/api/src/lib/application/calendar/get-events.ts
@@ -295,6 +295,7 @@ async function fetchAndCacheEvents(
 export async function getEventsForRange(
 	ctx: CalendarContext,
 	range: TimeRange,
+	forceRefresh = false,
 ): Promise<Result<CalendarEvent[], GetEventsError>> {
 	const repository = ctx.eventRepository;
 
@@ -331,7 +332,7 @@ export async function getEventsForRange(
 
 		const lastSyncTime = lastSyncResult.value;
 
-		if (isCacheStale(lastSyncTime)) {
+		if (forceRefresh || isCacheStale(lastSyncTime)) {
 			// キャッシュが古い場合はプロバイダから取得
 			const provider = await createProviderFromConfig(ctx, calendarConfig);
 
@@ -433,10 +434,11 @@ export async function getEventsForRange(
  */
 export async function getEventsForToday(
 	ctx: CalendarContext,
+	forceRefresh?: boolean,
 ): Promise<Result<CalendarEvent[], GetEventsError>> {
 	const todayRange = getTodayRange();
 	const range = createTimeRange(todayRange.startDate, todayRange.endDate);
-	return getEventsForRange(ctx, range);
+	return getEventsForRange(ctx, range, forceRefresh);
 }
 
 /**
@@ -462,10 +464,11 @@ export async function getEventsForToday(
  */
 export async function getEventsForWeek(
 	ctx: CalendarContext,
+	forceRefresh?: boolean,
 ): Promise<Result<CalendarEvent[], GetEventsError>> {
 	const weekRange = getWeekRange();
 	const range = createTimeRange(weekRange.startDate, weekRange.endDate);
-	return getEventsForRange(ctx, range);
+	return getEventsForRange(ctx, range, forceRefresh);
 }
 
 /**
@@ -480,8 +483,9 @@ export async function getEventsForMonth(
 	ctx: CalendarContext,
 	year: number,
 	month: number,
+	forceRefresh?: boolean,
 ): Promise<Result<CalendarEvent[], GetEventsError>> {
 	const monthRange = getMonthRange(year, month);
 	const range = createTimeRange(monthRange.startDate, monthRange.endDate);
-	return getEventsForRange(ctx, range);
+	return getEventsForRange(ctx, range, forceRefresh);
 }

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -108,8 +108,9 @@ events.get("/", async (c) => {
 	// コンテキスト作成
 	const ctx = createCalendarContext(db, userId, cryptoKeyResult.value);
 
-	// クエリパラメータから range を取得
+	// クエリパラメータから range と force を取得
 	const range = c.req.query("range") || "today";
+	const force = c.req.query("force") === "true";
 
 	// range に応じた関数を呼び出し
 	let result: Awaited<ReturnType<typeof getEventsForToday>>;
@@ -131,11 +132,11 @@ events.get("/", async (c) => {
 			parsedMonth <= 12
 				? parsedMonth
 				: jstNow.getUTCMonth() + 1;
-		result = await getEventsForMonth(ctx, year, month);
+		result = await getEventsForMonth(ctx, year, month, force);
 	} else if (range === "week") {
-		result = await getEventsForWeek(ctx);
+		result = await getEventsForWeek(ctx, force);
 	} else {
-		result = await getEventsForToday(ctx);
+		result = await getEventsForToday(ctx, force);
 	}
 
 	if (isOk(result)) {


### PR DESCRIPTION
## Summary
- 設定画面の同期ボタンを押してもイベントが更新されない問題を修正
- バックエンドの `/events` エンドポイントに `force=true` パラメータを追加し、1時間キャッシュをバイパス可能に
- モバイル側の同期成功後に `force=true` でイベントを再取得するよう変更

## Test plan
- [ ] 設定画面で「同期」ボタンを押すとイベントが最新に更新される
- [ ] 通常のイベント取得（同期ボタン以外）は既存のキャッシュ動作のまま
- [ ] 今日・今週両方のイベントが同期後に更新される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar event data can now be force-refreshed for today, week, and month views to retrieve the latest information beyond cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->