### PR TITLE
Fix calendar sync, widget display, and OAuth authentication

### DIFF
--- a/mobile/modules/shared-user-defaults/ios/SharedUserDefaultsModule.swift
+++ b/mobile/modules/shared-user-defaults/ios/SharedUserDefaultsModule.swift
@@ -1,4 +1,5 @@
 import ExpoModulesCore
+import WidgetKit
 
 public class SharedUserDefaultsModule: Module {
     public func definition() -> ModuleDefinition {
@@ -11,6 +12,10 @@ public class SharedUserDefaultsModule: Module {
                 ])
             }
             defaults.set(value, forKey: key)
+            defaults.synchronize()
+
+            // Widget にタイムライン更新を通知
+            WidgetCenter.shared.reloadAllTimelines()
         }
 
         AsyncFunction("getItem") { (key: String, suiteName: String) -> String? in

--- a/mobile/targets/widget/Models/SharedDataStore.swift
+++ b/mobile/targets/widget/Models/SharedDataStore.swift
@@ -18,7 +18,12 @@ final class SharedDataStore {
             return nil
         }
 
-        return try? JSONDecoder().decode(WidgetData.self, from: data)
+        do {
+            return try JSONDecoder().decode(WidgetData.self, from: data)
+        } catch {
+            print("[Widget] WidgetData decode error: \(error)")
+            return nil
+        }
     }
 
     /// 今日のイベントを取得


### PR DESCRIPTION
## Summary

- タイムラインの22:00以降イベント切れ問題を修正
- Google OAuth認証でアカウント選択画面を強制表示
- Google Calendar再認証時のトークン保存・カレンダー検出を修正
- OAuth PKCEセッションをインメモリからD1に移行（Cloudflare Workers複数インスタンス対応）
- Medium WidgetをGoogle Calendar風の3日間イベントリスト表示に刷新
- ISO8601ミリ秒付き日時文字列のパース修正（widget/watch/watch-widget全ターゲット）
- Widget更新通知の追加（`WidgetCenter.shared.reloadAllTimelines()`）
- CodeRabbitレビュー指摘事項の全修正（PII保護、エラーハンドリング等）

## Changes

### Bug Fixes
- `TimelineView.tsx`: 22:00カットオフ問題の修正
- `CalendarEvent.swift` (widget/watch/watch-widget): `.withFractionalSeconds`対応でJS `toISOString()`出力を正しくパース
- `WatchDataStore.swift`: lastUpdated日時パースのミリ秒対応
- `SharedUserDefaultsModule.swift`: `synchronize()` + `reloadAllTimelines()` でWidget更新を即時反映
- `SharedDataStore.swift`: `try?` → `do-catch` でデコードエラーをログ出力
- `oauth-service.ts`: トークンリフレッシュ時のOAuthConfig受け渡し修正
- `auth.ts`: 再認証コールバックでトークン保存・カレンダー検出を実行

### New Features
- Medium Widget: 今後3日間のイベントを時系列リスト表示（日付セパレータ付き）
- `SharedDataStore.swift`: `getUpcomingEvents(days:)` メソッド追加

### Security & Infrastructure
- PKCEセッションストアをD1に移行（`0004_pkce_sessions.sql`）
- `auth.ts`: メールアドレスのマスキング処理追加
- `calendars.ts`: `savePkceSession`のエラーハンドリング追加

## Test plan

- [x] iOS Widgetでアプリ起動後に予定が表示されること
- [x] 今後3日間のイベントが時系列で表示されること
- [x] Google OAuth認証・再認証フローが正常に動作すること
- [x] TestFlightビルド成功・提出済み（v60）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Widgets now properly refresh when shared user data is updated.
  * Improved error handling and logging for widget data operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->