### PR TITLE
Fix Apple Watch not receiving events by adding WatchConnectivity

### DIFF
--- a/mobile/modules/shared-user-defaults/ios/SharedUserDefaultsModule.swift
+++ b/mobile/modules/shared-user-defaults/ios/SharedUserDefaultsModule.swift
@@ -1,9 +1,90 @@
 import ExpoModulesCore
 import WidgetKit
+import WatchConnectivity
+
+// Expo Modules の Module クラスは NSObject を継承していないため、
+// WCSessionDelegate を直接実装できない。別クラスで管理する。
+class WatchSessionManager: NSObject, WCSessionDelegate {
+    static let shared = WatchSessionManager()
+
+    private var session: WCSession?
+
+    private override init() {
+        super.init()
+    }
+
+    func activate() {
+        guard WCSession.isSupported() else {
+            print("[WatchSessionManager] WCSession はこのデバイスでサポートされていません")
+            return
+        }
+        let wcSession = WCSession.default
+        wcSession.delegate = self
+        wcSession.activate()
+        session = wcSession
+        print("[WatchSessionManager] WCSession activate() を呼び出しました")
+    }
+
+    func sendToWatch(key: String, value: String, suiteName: String) {
+        guard WCSession.isSupported() else {
+            print("[WatchSessionManager] WCSession 非サポート、送信スキップ")
+            return
+        }
+
+        guard let session = session else {
+            print("[WatchSessionManager] session が未初期化、送信スキップ")
+            return
+        }
+
+        guard session.isPaired else {
+            print("[WatchSessionManager] Watch がペアリングされていません、送信スキップ")
+            return
+        }
+
+        guard session.isWatchAppInstalled else {
+            print("[WatchSessionManager] Watch アプリがインストールされていません、送信スキップ")
+            return
+        }
+
+        // updateApplicationContext は最新の状態のみ保持し、バックグラウンドでも配信される
+        let contextKey = suiteName + ":" + key
+        do {
+            try session.updateApplicationContext([contextKey: value])
+            print("[WatchSessionManager] applicationContext を更新しました: \(contextKey)")
+        } catch {
+            print("[WatchSessionManager] applicationContext の更新に失敗: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - WCSessionDelegate（必須メソッド）
+
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if let error = error {
+            print("[WatchSessionManager] activation 失敗: \(error.localizedDescription)")
+        } else {
+            print("[WatchSessionManager] activation 完了: state=\(activationState.rawValue)")
+        }
+    }
+
+    // iOS 側では必須
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        print("[WatchSessionManager] session が inactive になりました")
+    }
+
+    // iOS 側では必須。再 activate で新しい Watch へ切り替え対応
+    func sessionDidDeactivate(_ session: WCSession) {
+        print("[WatchSessionManager] session が deactivate されました。再 activate します")
+        session.activate()
+    }
+}
 
 public class SharedUserDefaultsModule: Module {
     public func definition() -> ModuleDefinition {
         Name("SharedUserDefaults")
+
+        OnCreate {
+            WatchSessionManager.shared.activate()
+        }
 
         AsyncFunction("setItem") { (key: String, value: String, suiteName: String) in
             guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -16,6 +97,9 @@ public class SharedUserDefaultsModule: Module {
 
             // Widget にタイムライン更新を通知
             WidgetCenter.shared.reloadAllTimelines()
+
+            // Watch へベストエフォートで送信（失敗しても setItem 自体は成功とする）
+            WatchSessionManager.shared.sendToWatch(key: key, value: value, suiteName: suiteName)
         }
 
         AsyncFunction("getItem") { (key: String, suiteName: String) -> String? in

--- a/mobile/targets/watch/Models/WatchDataStore.swift
+++ b/mobile/targets/watch/Models/WatchDataStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WatchConnectivity
+import WidgetKit
 
 /// App Groups経由で親アプリのイベントデータを読み取り、WCSessionでも受信可能
 final class WatchDataStore: NSObject, ObservableObject, WCSessionDelegate {
@@ -41,6 +42,16 @@ final class WatchDataStore: NSObject, ObservableObject, WCSessionDelegate {
         DispatchQueue.main.async {
             self.loadFromAppGroup()
         }
+
+        // 未処理のapplicationContextがあればデータを読み込む
+        let context = session.receivedApplicationContext
+        if !context.isEmpty {
+            handleApplicationContext(context)
+        }
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        handleApplicationContext(applicationContext)
     }
 
     func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
@@ -65,10 +76,34 @@ final class WatchDataStore: NSObject, ObservableObject, WCSessionDelegate {
                 self.events = widgetData.events.sorted { $0.startDate < $1.startDate }
                 self.lastUpdated = WatchDataStore.parseISO8601(widgetData.lastUpdated)
                 self.saveToAppGroup(dataString)
+                WidgetCenter.shared.reloadAllTimelines()
             }
             replyHandler(["status": "ok"])
         } catch {
             replyHandler(["status": "error", "message": error.localizedDescription])
+        }
+    }
+
+    // MARK: - ApplicationContext Handler
+
+    /// applicationContextからイベントデータを抽出して更新する
+    private func handleApplicationContext(_ context: [String: Any]) {
+        // iPhone側はキーを "suiteName:key" 形式で送信する
+        let contextKey = appGroupId + ":" + dataKey
+        guard let jsonString = context[contextKey] as? String,
+              let data = jsonString.data(using: .utf8) else { return }
+
+        do {
+            let widgetData = try JSONDecoder().decode(WatchEventData.self, from: data)
+            DispatchQueue.main.async {
+                self.events = widgetData.events.sorted { $0.startDate < $1.startDate }
+                self.lastUpdated = WatchDataStore.parseISO8601(widgetData.lastUpdated)
+                self.saveToAppGroup(jsonString)
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        } catch {
+            // デコード失敗時はログ出力のみ（UIへの影響なし）
+            print("[WatchDataStore] applicationContextのデコードに失敗: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary

- App Groups は同一デバイス上の拡張間でのみ共有されるため、iPhone → Apple Watch のデータ同期には WatchConnectivity が必要
- `SharedUserDefaultsModule` に `WatchSessionManager` を追加し、`setItem()` 時に `updateApplicationContext()` で Watch へ送信
- `WatchDataStore` に `didReceiveApplicationContext` ハンドラを追加し、受信データを Watch ローカル App Groups に保存 + コンプリケーション更新

## データフロー

```
iPhone App → SharedUserDefaultsModule.setItem()
  ├→ UserDefaults(App Groups) → iPhone Widget ✅ (既存)
  └→ WCSession.updateApplicationContext() → Watch App (WatchDataStore)
       └→ Watch ローカル App Groups に保存 → Watch Widget ✅ (NEW)
```

## Test plan

- [ ] EAS production ビルド成功 ✅
- [ ] TestFlight 提出済み ✅
- [ ] Apple Watch コンプリケーションにイベントが表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data synchronization now available between iPhone and Apple Watch, enabling the Watch app to automatically receive and display updates made on iPhone
  * Watch widgets automatically refresh when data is updated
  * Improved cross-device data consistency and synchronization reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->